### PR TITLE
Lint settings

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,73 @@
+IndentWidth: 4
+UseTab: Never
+ColumnLimit: 100 # Maximimum line length
+SortIncludes: true
+
+SpacesInParentheses: true # ( a + b ) instead of (a + b)
+SpacesInContainerLiterals: true
+# Example:
+# std::vector<int> values = { 1, 2, 3, 4 };
+
+SpaceBeforeSquareBrackets: false
+# Example:
+# int array[10];
+
+PointerAlignment: Right # int *ptr
+
+AlignTrailingComments: true
+# Example:
+# int   a = 5;      // Variable a
+# float b = 10.0;   // Variable b
+# char  c = 'c';    // Variable c
+
+BreakBeforeBraces: Allman
+# Example:
+# void Function()
+# {
+#     if (condition)
+#     {
+#         // Do something
+#     }
+# }
+
+AlignConsecutiveDeclarations: true
+# Example:
+# int    a   = 5;
+# float  b   = 10.0;
+# char   c   = 'c';
+# double pi  = 3.14159;
+
+AllowShortFunctionsOnASingleLine: All
+# Allows all short functions to be on a single line.
+# Example:
+# int getValue() { return 42; }
+# void setFlag(bool flag) { this->flag = flag; }
+
+SpaceAfterCStyleCast: true
+# Adds a space after C-style casts
+# int value = (int) someFloat instaed of (int)someFloat
+
+ReflowComments: true
+# Example:
+# // This is a very long comment that exceeds the line limit, so it will be wrapped
+# // automatically like this
+
+IndentCaseLabels: true
+# Example:
+# switch (value) {
+#     case 1:
+#         break;
+# }
+# versus
+# switch (value) {
+# case1:
+#   break;
+
+AlignAfterOpenBracket: Align
+# Aligns arguments if using line break
+# Example:
+# int sum = calculateSum(a, b,
+#                        c, d);
+# versus
+# int sum = calculateSum(a, b,
+# c, d);

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,36 @@
+Checks: >
+  -*,                                     
+  bugprone-*,                             
+  cppcoreguidelines-*,                    
+  modernize-*,-modernize-use-auto,-modernize-use-trailing-return-type,        
+  performance-*,                          
+  readability-*,                          
+  misc-*,                                 
+  -cppcoreguidelines-avoid-magic-numbers, 
+  -readability-magic-numbers,             
+  -cppcoreguidelines-pro-bounds-array-to-pointer-decay, 
+  -cppcoreguidelines-pro-bounds-constant-array-index
+
+CheckOptions:
+  # Standardized naming conventions:
+  - key: readability-identifier-naming.ClassCase
+    value: PascalCase # Class names (e.g., MyClass)
+
+  - key: readability-identifier-naming.StructCase
+    value: PascalCase # Struct names(e.g., MyStruct)
+
+  - key: readability-identifier-naming.FunctionCase
+    value: camelCase # Function names (e.g., myFunction)
+
+  - key: readability-identifier-naming.MethodCase
+    value: camelCase # Method names (e.g., myMethod)
+
+  - key: readability-identifier-naming.VariableCase
+    value: snake_case # Variable names (e.g., my_variable)
+
+  - key: readability-identifier-naming.PrivateMemberPrefix
+    value: _ # Private member variables should have underscores (e.g., _my_variable)
+
+  # Enforce initialization of all member variables in constructors
+  - key: cppcoreguidelines-pro-type-member-init.HaltOnMissingMemberInit
+    value: "true"


### PR DESCRIPTION
Added settings for `.clang-format` and `.clang-tidy`. For Visual Studio code, it will require the Clang Format and Clang Tidy plugins to provide lint support. 

The `.clang-format` file sets up formatting rules, which can be configured to autoformat on save.

The `.clang-tidy` file sets up linting, which will throw errors and warnings for not using the specific naming convention and a few other common pitfalls. 

It's an opinionated setup, but we don't have to go with everything here.