### PR TITLE
Basic build - Local Linting and Formatting

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,19 +1,19 @@
-Checks:
-  - "-*"
-  - "bugprone-*"
-  - "-bugprone-easily-swappable-parameters"
-  - "cppcoreguidelines-*"
-  - "modernize-*"
-  - "-modernize-use-auto"
-  - "-modernize-use-trailing-return-type"
-  - "performance-*"
-  - "readability-*"
-  - "misc-*"
-  - "-cppcoreguidelines-avoid-magic-numbers"
-  - "-readability-magic-numbers"
-  - "-cppcoreguidelines-pro-bounds-array-to-pointer-decay"
-  - "-cppcoreguidelines-pro-bounds-constant-array-index"
-  - "readability-identifier-naming"
+Checks: >
+  -*,
+  bugprone-*,
+  -bugprone-easily-swappable-parameters,
+  cppcoreguidelines-*,
+  modernize-*,
+  -modernize-use-auto,
+  -modernize-use-trailing-return-type,
+  performance-*,
+  readability-*,
+  misc-*,
+  -cppcoreguidelines-avoid-magic-numbers,
+  -readability-magic-numbers,
+  -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+  -cppcoreguidelines-pro-bounds-constant-array-index,
+  readability-identifier-naming
 
 CheckOptions:
   # Standardized naming conventions:

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -32,6 +32,7 @@ jobs:
           step-summary: true
           tidy-review: true
           format-review: true
+          database: "./build/compile_commands.json"
 
       - name: Report failure
         if: steps.linter.outputs.checks-failed != 0

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -3,32 +3,36 @@ name: lint-format
 on: [pull_request]
 
 permissions:
-    contents: write
-    pull-requests: write
+  contents: write
+  pull-requests: write
 
 jobs:
   lint:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Create build directory # needed for linting
-      run: mkdir -p build
-    - uses: cpp-linter/cpp-linter-action@v2
-      id: linter
-      env:
+      - uses: actions/checkout@v4
+      - name: Create build directory # needed for linting
+        run: |
+          rm -rf build
+          mkdir -p build
+          cd build
+          cmake ..
+      - uses: cpp-linter/cpp-linter-action@v2
+        id: linter
+        env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      with:
-        version: '18'
-        style: 'file'
-        tidy-checks: ''
-        no-lgtm: false
-        thread-comments: true
-        step-summary: true
-        tidy-review: true
-        format-review: true
+        with:
+          version: "18"
+          style: "file"
+          tidy-checks: ""
+          no-lgtm: false
+          thread-comments: true
+          step-summary: true
+          tidy-review: true
+          format-review: true
 
-    - name: Report failure
-      if: steps.linter.outputs.checks-failed != 0
-      run: exit 1
+      - name: Report failure
+        if: steps.linter.outputs.checks-failed != 0
+        run: exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Name of my executable
 emu
 
+# Env files
+.env
+
 # Ignore object files and static libraries
 *.o
 *.a
@@ -108,3 +111,7 @@ fceux/
 
 # Ignore any other common or custom build directories
 /build/
+.vscode/
+
+# Local tooling
+lint.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,14 @@ set( CMAKE_EXPORT_COMPILE_COMMANDS ON )
 # C++ 17 standard
 set( CMAKE_CXX_STANDARD 17 )
 set( CMAKE_CXX_STANDARD_REQUIRED ON )
-add_compile_options( -Wall -Wextra -Wpedantic -Werror )
 
+if(MSVC)
+  # If in visual studio
+  add_compile_options(/W4 /WX) # /W4 for high warning level, /WX to treat warnings as errors
+else()
+  # GCC/Clang warning flags
+  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+endif()
 
 # Include directories
 include_directories( include )

--- a/README.md
+++ b/README.md
@@ -29,9 +29,30 @@ chmod +x scripts/build.sh scripts/clean.sh scripts/run.sh scripts/test.sh
 ./scripts/test.sh           # Run unit tests
 ```
 
+Linting and formatting locally:
+
+```bash
+# If you have clang-tidy and clang-format installed
+find src/ -name '*.cpp' -exec clang-tidy -p build -header-filter='.*' {} \\; # Linting
+find src/ -name '*.cpp' -exec clang-format -i {} \; # Apply formatting
+```
+
+Linting and formatting with Docker
+
+```bash
+docker build -t project-linter -f docker/lint/Dockerfile .
+
+# Linting
+docker run project-linter
+
+# Linting and apply formatting
+docker run --rm -v "$(pwd)/src":/usr/src/app/src project-linter
+```
+
 ## Contribution Guidelines
 
 - Start early; don’t wait until the due date to contribute. Respect teammates’ time by submitting quality contributions.
+- Lint and format the codebase locally before submitting a PR.
 - Research each component thoroughly before working on it.
 - Stay updated with the codebase, even if you didn't write it.
-- If you fall behind, ask for help.
+- If something is confusing, ask your teammates.

--- a/README.md
+++ b/README.md
@@ -21,11 +21,12 @@ ctest    # Run unit tests
 Make scripts executable and use them to build, clean, run, or test:
 
 ```bash
-chmod +x build.sh clean.sh run.sh test.sh
-./build.sh          # Build project
-./clean.sh          # Clean build cache/executables
-./run.sh <name>     # Run specified executable in build folder
-./test.sh           # Run unit tests
+# From the root directory:
+chmod +x scripts/build.sh scripts/clean.sh scripts/run.sh scripts/test.sh
+./scripts/build.sh          # Build project
+./scripts/clean.sh          # Clean build cache/executables
+./scripts/run.sh <name>     # Run specified executable in build folder
+./scripts/test.sh           # Run unit tests
 ```
 
 ## Contribution Guidelines

--- a/docker/lint/Dockerfile
+++ b/docker/lint/Dockerfile
@@ -1,0 +1,34 @@
+# Ubuntu LTS Image
+FROM ubuntu:22.04
+
+# No interactive prompts during installation
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install necessary packages
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    build-essential \
+    clang \
+    clang-tidy \
+    clang-format \
+    cmake \
+    git \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set the working directory and copy the current directory contents
+WORKDIR /usr/src/app
+COPY . /usr/src/app
+
+# Remove any existing build directory and start a fresh build to generate compile_commands.json
+RUN rm -rf build && \
+    mkdir build && \
+    cd build && \
+    cmake ..
+
+# Expose the working directory as a volume to persist output files
+VOLUME ["/usr/src/app"]
+
+# Run the lint.sh script when the container starts
+# CMD ["bash", "-c", "find src/ -name '*.cpp' -exec clang-tidy -p build -header-filter='.*' {} \\;"]
+CMD ["bash", "-c", "find src/ -name '*.cpp' -exec clang-format -i {} \\; && find src/ -name '*.cpp' -exec clang-tidy -p build -header-filter='.*' {} \\;"]

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 
-# build.sh
+# scripts/build.sh
 # An optional script to create a build with CMake
-# To run, provide permissions first: chmod +x build.sh
-# Then, run the script: ./build.sh
+# To run, provide permissions first: chmod +x scripts/build.sh
+# Then, run the script: ./scripts/build.sh
 
 # Set the build directory (adjust if your build directory is in a different location)
 BUILD_DIR="build"
+cd "$(dirname "$0")/.." || exit 1 # run from the project root directory
 
 echo "Starting build process..."
 

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 
-# clean.sh
+# scripts/clean.sh
 # Optional script to clean CMake build files and executables.
-# To use, set proper permissions: chmod +x clean.sh
-# Usage: ./clean.sh
+# To use, set proper permissions: chmod +x scripts/clean.sh
+# Usage: ./scripts/clean.sh
 
 # Set the build directory (adjust if your build directory is in a different location)
 BUILD_DIR="build"
+cd "$(dirname "$0")/.." || exit 1 # run from the project root directory
 
 echo "Cleaning CMake build files..."
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
-# run.sh
+# scripts/run.sh
 # An optional script to run the executable after building it.
-# Provide permissions to the script by running `chmod +x run.sh`.
-# Run with `./run.sh <executable_name>`.
+# Provide permissions to the script by running `chmod +x scripts/run.sh`.
+# Run with `./scripts/run.sh <executable_name>`.
 
 BUILD_DIR="build"
+cd "$(dirname "$0")/.." || exit 1 # run from the project root directory
 
 # Check for the executable name argument
 if [ -z "$1" ]; then
-	echo "Usage: ./run.sh <executable_name>"
+	echo "Usage: ./scripts/run.sh <executable_name>"
 	exit 1
 fi
 
@@ -16,7 +17,7 @@ EXECUTABLE="$BUILD_DIR/$1"
 
 # Check if the build directory exists
 if [ ! -d "$BUILD_DIR" ]; then
-	echo "Build directory '$BUILD_DIR' does not exist. Try running ./build.sh first."
+	echo "Build directory '$BUILD_DIR' does not exist. Try running ./scripts/build.sh first."
 	exit 1
 fi
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
-# test.sh
+# scripts/test.sh
 # Optional test script to run CTest in the build directory
-# Give file permission to execute: chmod +x test.sh
-# run script: ./test.sh
+# Give file permission to execute: chmod +x scripts/test.sh
+# Run script: ./scripts/test.sh
 
 BUILD_DIR="build"
+cd "$(dirname "$0")/.." || exit 1 # run from the project root directory
 
 # Check if the build directory exists
 if [ ! -d "$BUILD_DIR" ]; then
-	echo "Error: Build directory '$BUILD_DIR' does not exist. Please run ./build.sh first."
+	echo "Error: Build directory '$BUILD_DIR' does not exist. Please run ./scripts/build.sh first."
 	exit 1
 fi
 
@@ -28,5 +29,5 @@ else
 fi
 
 # Isolating a specific test
-# ./test.sh "CPUTest.IMM" # Immediate addressing test
-# ./test.sh "CPUTest.xEA" # Test for opcode 0xEA (JMP)
+# ./scripts/test.sh "CPUTest.IMM" # Immediate addressing test
+# ./scripts/test.sh "CPUTest.xEA" # Test for opcode 0xEA (JMP)

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -1,5 +1,6 @@
 // cpu.cpp
 
+#include "cpu.h"
 #include "bus.h"
 CPU::CPU( Bus *bus ) : _bus( bus ) {} // initialize CPU with pointer to bus
 


### PR DESCRIPTION
Summary of changes:
- Moved scripts to their own folder
- Provided info in the Readme on how to run `clang-tidy` and `clang-format` locally
- Implemented a Dockerized version of `clang-tidy` and `clang-format`
- Added flag settings for Visual Studio compiler

Please see the commit history for more details