### PR TITLE
JMP, JSR, RTS, RTI, BRK and some bitwise instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,17 +40,14 @@ find src/ -name '*.cpp' -exec clang-format -i {} \; # Apply formatting
 Linting and formatting with Docker
 
 ```bash
-# B
+# Build the docker image
 docker build -t project-linter -f docker/alpine-Dockerfile .
 
-# Linting/formatting checks (this will apply formatting when run locally)
-docker run -v $(pwd):/workspace -w /workspace project-linter lint
-```
-
-Building with Docker
-
-```bash
+# Build the project
 docker run -v $(pwd):/workspace -w /workspace project-linter build
+
+# Linting/formatting checks (this will apply fixes when run locally)
+docker run -v $(pwd):/workspace -w /workspace project-linter lint
 ```
 
 Docker build information is stored in a separate build_container directory. The build.sh
@@ -59,6 +56,7 @@ script will determine which directory to use based on the environment.
 ## Testing
 
 Testing locally
+
 ```bash
 # From the root directory:
 # To run all tests
@@ -66,9 +64,11 @@ Testing locally
 
 # To run an individual test, add the test name as an argument
 ./scripts/test.sh "CPUTestFixture.IMM" # Immediate addressing test
+./scripts/test.sh "CPUTestFixture.x29" # Test opcode 29, AND Immediate
 ```
 
 Testing with Docker
+
 ```bash
 # Ensure that the container is built, and that you have build the project as described
 # in the above section.
@@ -79,3 +79,4 @@ docker run -v $(pwd):/workspace -w /workspace project-linter test
 # To run an individual test, add the test name as an argument
 docker run -v $(pwd):/workspace -w /workspace project-linter test  "CPUTestFixture.IMM" # Immediate addressing test
 ```
+

--- a/include/cpu.h
+++ b/include/cpu.h
@@ -122,6 +122,10 @@ class CPU
     // Compare helper
     void CompareAddressWithRegister( u16 address, u8 reg );
 
+    // Push/Pop helper
+    void               StackPush( u8 value );
+    [[nodiscard]] auto StackPop() -> u8;
+
     /*
     ################################################################
     ||                                                            ||

--- a/include/cpu.h
+++ b/include/cpu.h
@@ -216,4 +216,10 @@ class CPU
     void RTS( u16 address );
     void RTI( u16 address );
     void BRK( u16 address );
+
+    // Bitwise
+    void AND( u16 address );
+    void EOR( u16 address );
+    void ORA( u16 address );
+    void BIT( u16 address );
 };

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -77,7 +77,7 @@ case "$1" in
     # Run clang-tidy on both .cpp and .h files, and check for issues
     echo "Running clang-tidy..."
     for file in $(find src/ include/ -name '*.cpp' -o -name '*.h'); do
-      clang-tidy -p "$BUILD_DIR" -header-filter='.*' "$file" || lint_failures=1
+      clang-tidy -p "$BUILD_DIR" -header-filter='.*' "$file" -fix || lint_failures=1
     done
 
     # Report failure if clang-tidy found issues

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -1482,8 +1482,8 @@ void CPU::RTS( const u16 address )
      *   RTS: 60(6)
      */
     (void) address;
-    u16 low = StackPop();
-    u16 high = StackPop();
+    u16 const low = StackPop();
+    u16 const high = StackPop();
     _pc = ( high << 8 ) | low;
     _pc++;
 }
@@ -1497,13 +1497,13 @@ void CPU::RTI( const u16 address )
      *   RTI: 40(6)
      */
     (void) address;
-    u8 status = StackPop();
+    u8 const status = StackPop();
 
     // Ignore the break flag and ensure the unused flag (bit 5) is set
     _p = ( status & ~Break ) | Unused;
 
-    u16 low = StackPop();
-    u16 high = StackPop();
+    u16 const low = StackPop();
+    u16 const high = StackPop();
     _pc = ( high << 8 ) | low;
 }
 
@@ -1526,8 +1526,8 @@ void CPU::BRK( const u16 address )
     StackPush( _p | Break | Unused );
 
     // Set PC to the value at the interrupt vector (0xFFFE)
-    u16 low = Read( 0xFFFE );
-    u16 high = Read( 0xFFFF );
+    u16 const low = Read( 0xFFFE );
+    u16 const high = Read( 0xFFFF );
     _pc = ( high << 8 ) | low;
 
     // Set the interrupt disable flag

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -572,6 +572,26 @@ void CPU::CompareAddressWithRegister( u16 address, u8 reg )
     ( reg >= value ) ? SetFlags( Status::Carry ) : ClearFlags( Status::Carry );
 }
 
+void CPU::StackPush( u8 value )
+{
+    /*
+     * @brief Push a value onto the stack
+     * The stack pointer is decremented and the value is written to the stack
+     * Stack addresses are between 0x0100 and 0x01FF
+     */
+    Write( 0x0100 + _s--, value );
+}
+
+u8 CPU::StackPop()
+{
+    /*
+     * @brief Pop a value from the stack
+     * The stack pointer is incremented and the value is read from the stack
+     * Stack addresses are between 0x0100 and 0x01FF
+     */
+    return Read( 0x0100 + ++_s );
+}
+
 /*
 ################################################################
 ||                                                            ||

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -1612,7 +1612,7 @@ void CPU::BIT( const u16 address )
      *   BIT Absolute: 2C(4)
      */
 
-    u8 value = Read( address );
+    u8 const value = Read( address );
     SetZeroAndNegativeFlags( _a & value );
 
     // Set overflow flag to bit 6 of value

--- a/tests/cpu_test.cpp
+++ b/tests/cpu_test.cpp
@@ -427,34 +427,34 @@ To run all tests:
 
 /* CPU_TEST( SAMPLE, JSON, SANITY_CHECK, "temp.json" ); */
 CPU_TEST( 00, BRK, Implied, "00.json" );
-/* CPU_TEST( 01, ORA, IndirectX, "01.json" ); */
-/* CPU_TEST( 05, ORA, ZeroPage, "05.json" ); */
+CPU_TEST( 01, ORA, IndirectX, "01.json" );
+CPU_TEST( 05, ORA, ZeroPage, "05.json" );
 CPU_TEST( 06, ASL, ZeroPage, "06.json" );
 CPU_TEST( 08, PHP, Implied, "08.json" );
-/* CPU_TEST( 09, ORA, Immediate, "09.json" ); */
+CPU_TEST( 09, ORA, Immediate, "09.json" );
 CPU_TEST( 0A, ASL, Accumulator, "0a.json" );
-/* CPU_TEST( 0D, ORA, Absolute, "0d.json" ); */
+CPU_TEST( 0D, ORA, Absolute, "0d.json" );
 CPU_TEST( 0E, ASL, Absolute, "0e.json" );
 CPU_TEST( 10, BPL, Relative, "10.json" );
-/* CPU_TEST( 11, ORA, IndirectY, "11.json" ); */
-/* CPU_TEST( 15, ORA, ZeroPageX, "15.json" ); */
+CPU_TEST( 11, ORA, IndirectY, "11.json" );
+CPU_TEST( 15, ORA, ZeroPageX, "15.json" );
 CPU_TEST( 16, ASL, ZeroPageX, "16.json" );
 CPU_TEST( 18, CLC, Implied, "18.json" );
-/* CPU_TEST( 19, ORA, AbsoluteY, "19.json" ); */
-/* CPU_TEST( 1D, ORA, AbsoluteX, "1d.json" ); */
+CPU_TEST( 19, ORA, AbsoluteY, "19.json" );
+CPU_TEST( 1D, ORA, AbsoluteX, "1d.json" );
 CPU_TEST( 1E, ASL, AbsoluteX, "1e.json" );
 CPU_TEST( 20, JSR, Absolute, "20.json" );
 /* CPU_TEST( 21, AND, IndirectX, "21.json" ); */
-/* CPU_TEST( 24, BIT, ZeroPage, "24.json" ); */
+CPU_TEST( 24, BIT, ZeroPage, "24.json" );
 /* CPU_TEST( 25, AND, ZeroPage, "25.json" ); */
 CPU_TEST( 26, ROL, ZeroPage, "26.json" );
 CPU_TEST( 28, PLP, Implied, "28.json" );
 /* CPU_TEST( 29, AND, Immediate, "29.json" ); */
 CPU_TEST( 2A, ROL, Accumulator, "2a.json" );
-/* CPU_TEST( 2C, BIT, Absolute, "2c.json" ); */
+CPU_TEST( 2C, BIT, Absolute, "2c.json" );
 /* CPU_TEST( 2D, AND, Absolute, "2d.json" ); */
 CPU_TEST( 2E, ROL, Absolute, "2e.json" );
-/* CPU_TEST( 30, BMI, Relative, "30.json" ); */
+CPU_TEST( 30, BMI, Relative, "30.json" );
 /* CPU_TEST( 31, AND, IndirectY, "31.json" ); */
 /* CPU_TEST( 35, AND, ZeroPageX, "35.json" ); */
 CPU_TEST( 36, ROL, ZeroPageX, "36.json" );
@@ -463,22 +463,22 @@ CPU_TEST( 38, SEC, Implied, "38.json" );
 /* CPU_TEST( 3D, AND, AbsoluteX, "3d.json" ); */
 CPU_TEST( 3E, ROL, AbsoluteX, "3e.json" );
 CPU_TEST( 40, RTI, Implied, "40.json" );
-/* CPU_TEST( 41, EOR, IndirectX, "41.json" ); */
-/* CPU_TEST( 45, EOR, ZeroPage, "45.json" ); */
+CPU_TEST( 41, EOR, IndirectX, "41.json" );
+CPU_TEST( 45, EOR, ZeroPage, "45.json" );
 CPU_TEST( 46, LSR, ZeroPage, "46.json" );
 CPU_TEST( 48, PHA, Implied, "48.json" );
-/* CPU_TEST( 49, EOR, Immediate, "49.json" ); */
+CPU_TEST( 49, EOR, Immediate, "49.json" );
 CPU_TEST( 4A, LSR, Accumulator, "4a.json" );
 CPU_TEST( 4C, JMP, Absolute, "4c.json" );
-/* CPU_TEST( 4D, EOR, Absolute, "4d.json" ); */
+CPU_TEST( 4D, EOR, Absolute, "4d.json" );
 CPU_TEST( 4E, LSR, Absolute, "4e.json" );
 CPU_TEST( 50, BVC, Relative, "50.json" );
-/* CPU_TEST( 51, EOR, IndirectY, "51.json" ); */
-/* CPU_TEST( 55, EOR, ZeroPageX, "55.json" ); */
+CPU_TEST( 51, EOR, IndirectY, "51.json" );
+CPU_TEST( 55, EOR, ZeroPageX, "55.json" );
 CPU_TEST( 56, LSR, ZeroPageX, "56.json" );
 CPU_TEST( 58, CLI, Implied, "58.json" );
-/* CPU_TEST( 59, EOR, AbsoluteY, "59.json" ); */
-/* CPU_TEST( 5D, EOR, AbsoluteX, "5d.json" ); */
+CPU_TEST( 59, EOR, AbsoluteY, "59.json" );
+CPU_TEST( 5D, EOR, AbsoluteX, "5d.json" );
 CPU_TEST( 5E, LSR, AbsoluteX, "5e.json" );
 CPU_TEST( 60, RTS, Implied, "60.json" );
 CPU_TEST( 61, ADC, IndirectX, "61.json" );


### PR DESCRIPTION
Added new instructions with passing tests.

Added `-fix` arg to `clang-tidy` in `entrypoint.sh` to apply fixes. @coopeaus we want the lint action to apply fixes, right? I've had cases in the past where applying linting broke code, but it was almost always because of bad implementation. Let me know if you prefer handling fixes manually instead. 

I also took some of the bitwise instructions since there are quite a few of them and left AND for @AnthonySchool 