### PR TITLE
Opcodes for AND implemented, NOP implemented

### DIFF
--- a/include/cpu.h
+++ b/include/cpu.h
@@ -154,6 +154,9 @@ class CPU
     ################################################################
       */
 
+    // NOP
+    void NOP( u16 address );
+
     // Load/Store
     void LDA( u16 address );
     void LDX( u16 address );

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -15,6 +15,9 @@ CPU::CPU( Bus *bus ) : _bus( bus ), _opcodeTable{}
     ################################################################
     */
 
+    // NOP
+    _opcodeTable[0xEA] = InstructionData{"NOP_Implied", &CPU::NOP, &CPU::IMP, 2};
+
     // LDA
     _opcodeTable[0xA9] = InstructionData{ "LDA_Immediate", &CPU::LDA, &CPU::IMM, 2 };
     _opcodeTable[0xA5] = InstructionData{ "LDA_ZeroPage", &CPU::LDA, &CPU::ZPG, 3 };
@@ -172,7 +175,15 @@ CPU::CPU( Bus *bus ) : _bus( bus ), _opcodeTable{}
     _opcodeTable[0x40] = InstructionData{ "RTI_Implied", &CPU::RTI, &CPU::IMP, 6 };
     _opcodeTable[0x00] = InstructionData{ "BRK_Implied", &CPU::BRK, &CPU::IMP, 7 };
 
-    // TODO: AND
+    // AND
+    _opcodeTable[0x29] = InstructionData{ "AND_Immediate", &CPU::AND, &CPU::IMM, 2 };
+    _opcodeTable[0x25] = InstructionData{ "AND_ZeroPage", &CPU::AND, &CPU::ZPG, 3 };
+    _opcodeTable[0x35] = InstructionData{ "AND_ZeroPageX", &CPU::AND, &CPU::ZPGX, 4 };
+    _opcodeTable[0x2D] = InstructionData{ "AND_Absolute", &CPU::AND, &CPU::ABS, 4 };
+    _opcodeTable[0x3D] = InstructionData{ "AND_AbsoluteX", &CPU::AND, &CPU::ABSX, 4 };
+    _opcodeTable[0x39] = InstructionData{ "AND_AbsoluteY", &CPU::AND, &CPU::ABSY, 4 };
+    _opcodeTable[0x21] = InstructionData{ "AND_IndirectX", &CPU::AND, &CPU::INDX, 6 };
+    _opcodeTable[0x31] = InstructionData{ "AND_IndirectY", &CPU::AND, &CPU::INDY, 5 };
 
     // ORA
     _opcodeTable[0x09] = InstructionData{ "ORA_Immediate", &CPU::ORA, &CPU::IMM, 2 };
@@ -616,7 +627,7 @@ void CPU::BranchOnStatus( u16 offsetAddress, u8 flag, bool isSet )
         // Set _pc to the offset address, calculated by REL addressing mode
         _pc = offsetAddress;
 
-        // +1 cyles because we're taking a branch
+        // +1 cycles because we're taking a branch
         _cycles++;
 
         // Add another cycle if page boundary is crossed
@@ -679,6 +690,18 @@ u8 CPU::StackPop()
 * All complicated or reusable logic should be defined in the helper
 * methods.
 */
+
+void CPU::NOP( u16 address )
+{
+    /*
+     * @brief No operation
+     * N Z C I D V
+     * - - - - - -
+     * Usage and cycles:
+     * NOP Implied: EA(2)
+     */
+    (void)address;
+}
 
 void CPU::LDA( u16 address )
 {
@@ -1238,7 +1261,7 @@ void CPU::PLA( const u16 address )
     // Increment the stack pointer first
     SetStackPointer( GetStackPointer() + 1 );
 
-    // Get the acuumulator from the stack and set the zero and negative flags
+    // Get the accumulator from the stack and set the zero and negative flags
     SetAccumulator( Read( 0x100 + GetStackPointer() ) );
     SetZeroAndNegativeFlags( _a );
 }
@@ -1564,6 +1587,26 @@ void CPU::BRK( const u16 address )
 
     // Set the interrupt disable flag
     SetFlags( InterruptDisable );
+}
+
+void CPU::AND( u16 address )
+{
+    /* @brief XOR Memory with Accumulator
+     * N Z C I D V
+     * + + - - - -
+     *   Usage and cycles:
+     *   AND Immediate: 29(2)
+     *   AND Zero Page: 25(3)
+     *   AND Zero Page X: 35(4)
+     *   AND Absolute: 2D(4)
+     *   AND Absolute X: 3D(4+)
+     *   AND Absolute Y: 39(4+)
+     *   AND Indirect X: 21(6)
+     *   AND Indirect Y: 31(5+)
+     */
+    u8 const value = Read( address );
+    _a &= value;
+    SetZeroAndNegativeFlags( _a );
 }
 
 void CPU::ORA( const u16 address )

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -16,7 +16,7 @@ CPU::CPU( Bus *bus ) : _bus( bus ), _opcodeTable{}
     */
 
     // NOP
-    _opcodeTable[0xEA] = InstructionData{"NOP_Implied", &CPU::NOP, &CPU::IMP, 2};
+    _opcodeTable[0xEA] = InstructionData{ "NOP_Implied", &CPU::NOP, &CPU::IMP, 2 };
 
     // LDA
     _opcodeTable[0xA9] = InstructionData{ "LDA_Immediate", &CPU::LDA, &CPU::IMM, 2 };
@@ -700,7 +700,7 @@ void CPU::NOP( u16 address )
      * Usage and cycles:
      * NOP Implied: EA(2)
      */
-    (void)address;
+    (void) address;
 }
 
 void CPU::LDA( u16 address )

--- a/tests/cpu_test.cpp
+++ b/tests/cpu_test.cpp
@@ -444,23 +444,23 @@ CPU_TEST( 19, ORA, AbsoluteY, "19.json" );
 CPU_TEST( 1D, ORA, AbsoluteX, "1d.json" );
 CPU_TEST( 1E, ASL, AbsoluteX, "1e.json" );
 CPU_TEST( 20, JSR, Absolute, "20.json" );
-/* CPU_TEST( 21, AND, IndirectX, "21.json" ); */
+CPU_TEST( 21, AND, IndirectX, "21.json" );
 CPU_TEST( 24, BIT, ZeroPage, "24.json" );
-/* CPU_TEST( 25, AND, ZeroPage, "25.json" ); */
+CPU_TEST( 25, AND, ZeroPage, "25.json" );
 CPU_TEST( 26, ROL, ZeroPage, "26.json" );
 CPU_TEST( 28, PLP, Implied, "28.json" );
-/* CPU_TEST( 29, AND, Immediate, "29.json" ); */
+CPU_TEST( 29, AND, Immediate, "29.json" );
 CPU_TEST( 2A, ROL, Accumulator, "2a.json" );
 CPU_TEST( 2C, BIT, Absolute, "2c.json" );
-/* CPU_TEST( 2D, AND, Absolute, "2d.json" ); */
+CPU_TEST( 2D, AND, Absolute, "2d.json" );
 CPU_TEST( 2E, ROL, Absolute, "2e.json" );
 CPU_TEST( 30, BMI, Relative, "30.json" );
-/* CPU_TEST( 31, AND, IndirectY, "31.json" ); */
-/* CPU_TEST( 35, AND, ZeroPageX, "35.json" ); */
+CPU_TEST( 31, AND, IndirectY, "31.json" );
+CPU_TEST( 35, AND, ZeroPageX, "35.json" );
 CPU_TEST( 36, ROL, ZeroPageX, "36.json" );
 CPU_TEST( 38, SEC, Implied, "38.json" );
-/* CPU_TEST( 39, AND, AbsoluteY, "39.json" ); */
-/* CPU_TEST( 3D, AND, AbsoluteX, "3d.json" ); */
+CPU_TEST( 39, AND, AbsoluteY, "39.json" );
+CPU_TEST( 3D, AND, AbsoluteX, "3d.json" );
 CPU_TEST( 3E, ROL, AbsoluteX, "3e.json" );
 CPU_TEST( 40, RTI, Implied, "40.json" );
 CPU_TEST( 41, EOR, IndirectX, "41.json" );
@@ -565,7 +565,7 @@ CPU_TEST( E5, SBC, ZeroPage, "e5.json" );
 CPU_TEST( E6, INC, ZeroPage, "e6.json" );
 CPU_TEST( E8, INX, Implied, "e8.json" );
 CPU_TEST( E9, SBC, Immediate, "e9.json" );
-/* CPU_TEST( EA, NOP, Implied, "ea.json" ); */
+CPU_TEST( EA, NOP, Implied, "ea.json" );
 CPU_TEST( EC, CPX, Absolute, "ec.json" );
 CPU_TEST( ED, SBC, Absolute, "ed.json" );
 CPU_TEST( EE, INC, Absolute, "ee.json" );

--- a/tests/cpu_test.cpp
+++ b/tests/cpu_test.cpp
@@ -31,7 +31,7 @@ class CPUTestFixture : public ::testing::Test
 
     void                      RunTestCase( const json &testCase );
     void                      LoadStateFromJson( const json &jsonData, const std::string &state );
-    [[nodiscard]] std::string GetCPUStateString( const json        &jsonData,
+    [[nodiscard]] std::string GetCPUStateString( const json &       jsonData,
                                                  const std::string &state ) const;
 
     // Expose private methods
@@ -700,7 +700,7 @@ void CPUTestFixture::LoadStateFromJson( const json &jsonData, const std::string 
     }
 }
 
-std::string CPUTestFixture::GetCPUStateString( const json        &jsonData,
+std::string CPUTestFixture::GetCPUStateString( const json &       jsonData,
                                                const std::string &state ) const
 {
     /*
@@ -742,11 +742,9 @@ std::string CPUTestFixture::GetCPUStateString( const json        &jsonData,
            << std::setw( value_width ) << "ACTUAL" << '\n';
 
     // Function to format and print a line
-    auto print_line =
-        [&]( const std::string &label, const uint64_t expected, const uint64_t actual )
-    {
-        auto to_hex_decimal_string = []( const uint64_t value, const int width )
-        {
+    auto print_line = [&]( const std::string &label, const uint64_t expected,
+                           const uint64_t actual ) {
+        auto to_hex_decimal_string = []( const uint64_t value, const int width ) {
             std::stringstream str_stream;
             str_stream << std::hex << std::uppercase << std::setw( width ) << std::setfill( '0' )
                        << value << " (" << std::dec << value << ")";
@@ -798,8 +796,7 @@ std::string CPUTestFixture::GetCPUStateString( const json        &jsonData,
         uint8_t const  actual_value = cpu.Read( address );
 
         // Helper lambda to format values as "HEX (DECIMAL)"
-        auto format_value = []( const uint8_t value )
-        {
+        auto format_value = []( const uint8_t value ) {
             std::ostringstream oss;
             oss << std::hex << std::uppercase << std::setw( 2 ) << std::setfill( '0' )
                 << static_cast<int>( value ) << " (" << std::dec << static_cast<int>( value )


### PR DESCRIPTION
CPU.cpp and CPU.h were edited to implement opcodes for AND and to implement NOP. CPU_tests.cpp was edited to remove comments about NOP tests and AND tests. CPU.h was edited to declare NOP