### PR TITLE
Update tests

### DIFF
--- a/include/cpu.h
+++ b/include/cpu.h
@@ -231,4 +231,13 @@ class CPU
     void TXA( u16 address );
     void TAY( u16 address );
     void TYA( u16 address );
+
+    /*
+    ################################################
+    ||                                            ||
+    ||               Illegal Opcodes              ||
+    ||                                            ||
+    ################################################
+    */
+    void JAM( u16 address );
 };

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -705,7 +705,7 @@ u8 CPU::StackPop()
 * methods.
 */
 
-void CPU::NOP( u16 address )
+void CPU::NOP( u16 address ) // NOLINT
 {
     /*
      * @brief No operation

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -214,6 +214,20 @@ CPU::CPU( Bus *bus ) : _bus( bus ), _opcodeTable{}
     _opcodeTable[0x8A] = InstructionData{ "TXA_Implied", &CPU::TXA, &CPU::IMP, 2 };
     _opcodeTable[0xA8] = InstructionData{ "TAY_Implied", &CPU::TAY, &CPU::IMP, 2 };
     _opcodeTable[0x98] = InstructionData{ "TYA_Implied", &CPU::TYA, &CPU::IMP, 2 };
+
+    // Illegal - JAM (02, 12, 22, 32, 45, 52, 62, 72, 92, B2, D2, F2)
+    _opcodeTable[0x02] = InstructionData{ "JAM_Implied", &CPU::JAM, &CPU::IMP, 3 };
+    _opcodeTable[0x12] = InstructionData{ "JAM_Implied", &CPU::JAM, &CPU::IMP, 3 };
+    _opcodeTable[0x22] = InstructionData{ "JAM_Implied", &CPU::JAM, &CPU::IMP, 3 };
+    _opcodeTable[0x32] = InstructionData{ "JAM_Implied", &CPU::JAM, &CPU::IMP, 3 };
+    _opcodeTable[0x42] = InstructionData{ "JAM_Implied", &CPU::JAM, &CPU::IMP, 3 };
+    _opcodeTable[0x52] = InstructionData{ "JAM_Implied", &CPU::JAM, &CPU::IMP, 3 };
+    _opcodeTable[0x62] = InstructionData{ "JAM_Implied", &CPU::JAM, &CPU::IMP, 3 };
+    _opcodeTable[0x72] = InstructionData{ "JAM_Implied", &CPU::JAM, &CPU::IMP, 3 };
+    _opcodeTable[0x92] = InstructionData{ "JAM_Implied", &CPU::JAM, &CPU::IMP, 3 };
+    _opcodeTable[0xB2] = InstructionData{ "JAM_Implied", &CPU::JAM, &CPU::IMP, 3 };
+    _opcodeTable[0xD2] = InstructionData{ "JAM_Implied", &CPU::JAM, &CPU::IMP, 3 };
+    _opcodeTable[0xF2] = InstructionData{ "JAM_Implied", &CPU::JAM, &CPU::IMP, 3 };
 };
 
 // Getters
@@ -1721,4 +1735,22 @@ void CPU::TYA( const u16 address )
     (void) address;
     SetAccumulator( GetYRegister() );
     SetZeroAndNegativeFlags( GetAccumulator() );
+}
+
+/*
+################################################################
+||                                                            ||
+||                      Illegal Opcodes                       ||
+||                                                            ||
+################################################################
+*/
+void CPU::JAM( const u16 address ) // NOLINT
+{
+    /* @brief Illegal Opcode
+     * Freezes the hardware, usually never called
+     * Tom Harte tests include these, though, so for completeness, we'll add them
+     */
+    (void) address;
+    // Do nothing (undo the pc increment)
+    _pc--;
 }

--- a/tests/cpu_test.cpp
+++ b/tests/cpu_test.cpp
@@ -31,7 +31,7 @@ class CPUTestFixture : public ::testing::Test
 
     void                      RunTestCase( const json &testCase );
     void                      LoadStateFromJson( const json &jsonData, const std::string &state );
-    [[nodiscard]] std::string GetCPUStateString( const json &       jsonData,
+    [[nodiscard]] std::string GetCPUStateString( const json        &jsonData,
                                                  const std::string &state ) const;
 
     // Expose private methods
@@ -426,6 +426,14 @@ To run all tests:
 */
 
 /* CPU_TEST( SAMPLE, JSON, SANITY_CHECK, "temp.json" ); */
+
+/*
+################################
+||                            ||
+||      Official Opcodes      ||
+||                            ||
+################################
+*/
 CPU_TEST( 00, BRK, Implied, "00.json" );
 CPU_TEST( 01, ORA, IndirectX, "01.json" );
 CPU_TEST( 05, ORA, ZeroPage, "05.json" );
@@ -579,6 +587,135 @@ CPU_TEST( FE, INC, AbsoluteX, "fe.json" );
 CPU_TEST( F8, SED, Implied, "f8.json" );
 
 /*
+################################
+||                            ||
+||       Illegal Opcodes      ||
+||                            ||
+################################
+*/
+
+/* Illegal Jam
+ * These will jam the hardware are are generally not used.
+ * These should still be tested. They should not have any effect
+ */
+CPU_TEST( 02, JAM, Implied, "02.json" );
+CPU_TEST( 12, JAM, Implied, "12.json" );
+CPU_TEST( 22, JAM, Implied, "22.json" );
+CPU_TEST( 32, JAM, Implied, "32.json" );
+CPU_TEST( 42, JAM, Implied, "42.json" );
+CPU_TEST( 45, JAM, Implied, "42.json" );
+CPU_TEST( 52, JAM, Implied, "52.json" );
+CPU_TEST( 62, JAM, Implied, "62.json" );
+CPU_TEST( 72, JAM, Implied, "72.json" );
+CPU_TEST( 92, JAM, Implied, "92.json" );
+CPU_TEST( B2, JAM, Implied, "b2.json" );
+CPU_TEST( D2, JAM, Implied, "d2.json" );
+CPU_TEST( F2, JAM, Implied, "f2.json" );
+
+/* Illegal NOP */
+// CPU_TEST( 1A, NOP, Implied, "1a.json" );
+// CPU_TEST( 3A, NOP, Implied, "3a.json" );
+// CPU_TEST( 5A, NOP, Implied, "5a.json" );
+// CPU_TEST( 7A, NOP, Implied, "7a.json" );
+// CPU_TEST( DA, NOP, Implied, "da.json" );
+// CPU_TEST( FA, NOP, Implied, "fa.json" );
+// CPU_TEST( 80, NOP, Immediate, "80.json" );
+// CPU_TEST( 82, NOP, Immediate, "82.json" );
+// CPU_TEST( 89, NOP, Immediate, "89.json" );
+// CPU_TEST( C2, NOP, Immediate, "c2.json" );
+// CPU_TEST( E2, NOP, Immediate, "e2.json" );
+// CPU_TEST( 04, NOP, ZeroPage, "04.json" );
+// CPU_TEST( 44, NOP, ZeroPage, "44.json" );
+// CPU_TEST( 64, NOP, ZeroPage, "64.json" );
+// CPU_TEST( 14, NOP, ZeroPageX, "14.json" );
+// CPU_TEST( 34, NOP, ZeroPageX, "34.json" );
+// CPU_TEST( 54, NOP, ZeroPageX, "54.json" );
+// CPU_TEST( 74, NOP, ZeroPageX, "74.json" );
+// CPU_TEST( D4, NOP, ZeroPageX, "d4.json" );
+// CPU_TEST( F4, NOP, ZeroPageX, "f4.json" );
+// CPU_TEST( 0C, NOP, Absolute, "0c.json" );
+// CPU_TEST( 1C, NOP, AbsoluteX, "1c.json" );
+// CPU_TEST( 3C, NOP, AbsoluteX, "3c.json" );
+// CPU_TEST( 5C, NOP, AbsoluteX, "5c.json" );
+// CPU_TEST( 7C, NOP, AbsoluteX, "7c.json" );
+// CPU_TEST( DC, NOP, AbsoluteX, "dc.json" );
+// CPU_TEST( FC, NOP, AbsoluteX, "fc.json" );
+
+/* Illegal SL0 */
+// CPU_TEST( 07, SLO, ZeroPage, "07.json" );
+// CPU_TEST( 17, SLO, ZeroPageX, "17.json" );
+// CPU_TEST( 0F, SLO, Absolute, "0f.json" );
+// CPU_TEST( 1F, SLO, AbsoluteX, "1f.json" );
+// CPU_TEST( 1B, SLO, AbsoluteY, "1b.json" );
+// CPU_TEST( 03, SLO, IndirectX, "03.json" );
+// CPU_TEST( 13, SLO, IndirectY, "13.json" );
+
+/* Illegal RLA */
+// CPU_TEST( 27, RLA, ZeroPage, "27.json" );
+// CPU_TEST( 37, RLA, ZeroPageX, "37.json" );
+// CPU_TEST( 2F, RLA, Absolute, "2f.json" );
+// CPU_TEST( 3F, RLA, AbsoluteX, "3f.json" );
+// CPU_TEST( 3B, RLA, AbsoluteY, "3b.json" );
+// CPU_TEST( 23, RLA, IndirectX, "23.json" );
+// CPU_TEST( 33, RLA, IndirectY, "33.json" );
+
+/* Illegal SRE */
+// CPU_TEST( 47, SRE, ZeroPage, "47.json" );
+// CPU_TEST( 57, SRE, ZeroPageX, "57.json" );
+// CPU_TEST( 4F, SRE, Absolute, "4f.json" );
+// CPU_TEST( 5F, SRE, AbsoluteX, "5f.json" );
+// CPU_TEST( 5B, SRE, AbsoluteY, "5b.json" );
+// CPU_TEST( 43, SRE, IndirectX, "43.json" );
+// CPU_TEST( 53, SRE, IndirectY, "53.json" );
+
+/* Illegal RRA */
+// CPU_TEST( 67, RRA, ZeroPage, "67.json" );
+// CPU_TEST( 77, RRA, ZeroPageX, "77.json" );
+// CPU_TEST( 6F, RRA, Absolute, "6f.json" );
+// CPU_TEST( 7F, RRA, AbsoluteX, "7f.json" );
+// CPU_TEST( 7B, RRA, AbsoluteY, "7b.json" );
+// CPU_TEST( 63, RRA, IndirectX, "63.json" );
+// CPU_TEST( 73, RRA, IndirectY, "73.json" );
+
+/* Illegal SAX */
+// CPU_TEST( 87, SAX, ZeroPage, "87.json" );
+// CPU_TEST( 97, SAX, ZeroPageY, "97.json" );
+// CPU_TEST( 8F, SAX, Absolute, "8f.json" );
+// CPU_TEST( 83, SAX, IndirectX, "83.json" );
+
+/* Illegal LAX */
+// CPU_TEST( A7, LAX, ZeroPage, "a7.json" );
+// CPU_TEST( B7, LAX, ZeroPageY, "b7.json" );
+// CPU_TEST( AF, LAX, Absolute, "af.json" );
+// CPU_TEST( BF, LAX, AbsoluteY, "bf.json" );
+// CPU_TEST( A3, LAX, IndirectX, "a3.json" );
+// CPU_TEST( B3, LAX, IndirectY, "b3.json" );
+
+/* Illegal DCP */
+// CPU_TEST( C7, DCP, ZeroPage, "c7.json" );
+// CPU_TEST( D7, DCP, ZeroPageX, "d7.json" );
+// CPU_TEST( CF, DCP, Absolute, "cf.json" );
+// CPU_TEST( DF, DCP, AbsoluteX, "df.json" );
+// CPU_TEST( DB, DCP, AbsoluteY, "db.json" );
+// CPU_TEST( C3, DCP, IndirectX, "c3.json" );
+// CPU_TEST( D3, DCP, IndirectY, "d3.json" );
+
+/* Illegal ISC */
+// CPU_TEST( E7, ISC, ZeroPage, "e7.json" );
+// CPU_TEST( F7, ISC, ZeroPageX, "f7.json" );
+// CPU_TEST( EF, ISC, Absolute, "ef.json" );
+// CPU_TEST( FF, ISC, AbsoluteX, "ff.json" );
+// CPU_TEST( FB, ISC, AbsoluteY, "fb.json" );
+// CPU_TEST( E3, ISC, IndirectX, "e3.json" );
+// CPU_TEST( F3, ISC, IndirectY, "f3.json" );
+
+/* Illegal ALR */
+// CPU_TEST( 4B, ALR, Immediate, "4b.json" );
+
+/* Illegal ARR */
+// CPU_TEST( 6B, ARR, Immediate, "6b.json" );
+
+/*
 ################################################################
 ||                                                            ||
 ||                    Test Fixture Methods                    ||
@@ -700,7 +837,7 @@ void CPUTestFixture::LoadStateFromJson( const json &jsonData, const std::string 
     }
 }
 
-std::string CPUTestFixture::GetCPUStateString( const json &       jsonData,
+std::string CPUTestFixture::GetCPUStateString( const json        &jsonData,
                                                const std::string &state ) const
 {
     /*
@@ -742,9 +879,11 @@ std::string CPUTestFixture::GetCPUStateString( const json &       jsonData,
            << std::setw( value_width ) << "ACTUAL" << '\n';
 
     // Function to format and print a line
-    auto print_line = [&]( const std::string &label, const uint64_t expected,
-                           const uint64_t actual ) {
-        auto to_hex_decimal_string = []( const uint64_t value, const int width ) {
+    auto print_line =
+        [&]( const std::string &label, const uint64_t expected, const uint64_t actual )
+    {
+        auto to_hex_decimal_string = []( const uint64_t value, const int width )
+        {
             std::stringstream str_stream;
             str_stream << std::hex << std::uppercase << std::setw( width ) << std::setfill( '0' )
                        << value << " (" << std::dec << value << ")";
@@ -796,7 +935,8 @@ std::string CPUTestFixture::GetCPUStateString( const json &       jsonData,
         uint8_t const  actual_value = cpu.Read( address );
 
         // Helper lambda to format values as "HEX (DECIMAL)"
-        auto format_value = []( const uint8_t value ) {
+        auto format_value = []( const uint8_t value )
+        {
             std::ostringstream oss;
             oss << std::hex << std::uppercase << std::setw( 2 ) << std::setfill( '0' )
                 << static_cast<int>( value ) << " (" << std::dec << static_cast<int>( value )


### PR DESCRIPTION
Closes #74

I Added tests for illegal opcodes. We'll need them to run the nestest ROM, and implementing them is barely a stretch, as they're primarily combinations of opcodes we have already implemented.

I added opcodes that jam the hardware and and made them not increment the PC.

I fixed a minor issue with Clang Tidy wanting to turn NOP into a static type, which can cause a compilation error as well.