### PR TITLE
Implemented Mapper 1 Support 

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,6 +1,6 @@
 IndentWidth: 4
 UseTab: Never
-ColumnLimit: 100 # Maximimum line length
+ColumnLimit: 110 # Maximimum line length
 SortIncludes: false
 IncludeBlocks: Preserve
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ add_executable(emu
         src/bus.cpp
         src/cartridge.cpp
         src/mappers/mapper0.cpp
+        src/mappers/mapper1.cpp
 )
 
 # Apply compiler options to emu target
@@ -153,6 +154,8 @@ add_executable(cpu_test
         src/bus.cpp
         src/cartridge.cpp
         src/mappers/mapper0.cpp
+        src/mappers/mapper1.cpp
+        src/utils.cpp
 )
 
 add_executable(rom_test
@@ -161,6 +164,8 @@ add_executable(rom_test
   src/bus.cpp
   src/cartridge.cpp
   src/mappers/mapper0.cpp
+  src/mappers/mapper1.cpp
+  src/utils.cpp
 )
 # add other test executables here
 

--- a/include/cpu.h
+++ b/include/cpu.h
@@ -45,7 +45,7 @@ class CPU
     void               Write( u16 address, u8 data ) const;
 
     // Debugging
-    std::string DisassembleAtPC();
+    std::string LogLineAtPC( bool verbose = true );
 
   private:
     friend class CPUTestFixture; // Sometimes used for testing private methods
@@ -54,14 +54,13 @@ class CPU
     bool _imp = false; // Implicit addressing mode flag
 
     // Registers
-    u16 _pc = 0x0000; // Program counter (PC)
-    u8  _a = 0x00;    // Accumulator register (A)
-    u8  _x = 0x00;    // X register
-    u8  _y = 0x00;    // Y register
-    u8  _s = 0xFD;    // Stack pointer (SP)
-    u8  _p =
-        0x00 | Unused; // Status register (P), per the specs, the unused flag should always be set
-    u64 _cycles = 0;   // Number of cycles
+    u16 _pc = 0x0000;       // Program counter (PC)
+    u8  _a = 0x00;          // Accumulator register (A)
+    u8  _x = 0x00;          // X register
+    u8  _y = 0x00;          // Y register
+    u8  _s = 0xFD;          // Stack pointer (SP)
+    u8  _p = 0x00 | Unused; // Status register (P), per the specs, the unused flag should always be set
+    u64 _cycles = 0;        // Number of cycles
 
     // Instruction data
     struct InstructionData

--- a/include/mappers/mapper-base.h
+++ b/include/mappers/mapper-base.h
@@ -7,15 +7,24 @@ using u16 = uint16_t;
 using u32 = uint32_t;
 using u64 = uint64_t;
 
-/**
- * @brief Mapper base class
- * All other mappers will inherit from this class
- */
+enum class MirrorMode : u8
+{
+    Horizontal,
+    Vertical,
+    SingleLower,
+    SingleUpper,
+    FourScreen
+};
+
 class Mapper
 {
+    /**
+     * @brief Mapper base class
+     * All other mappers will inherit from this class
+     */
   public:
-    Mapper( size_t prg_size_bytes, size_t chr_size_bytes )
-        : _prg_KiB_capacity( prg_size_bytes ), _chr_KiB_capacity( chr_size_bytes )
+    Mapper( u8 prg_rom_banks, u8 chr_rom_banks )
+        : _prg_rom_banks( prg_rom_banks ), _chr_rom_banks( chr_rom_banks )
     {
     }
 
@@ -40,19 +49,21 @@ class Mapper
     virtual ~Mapper() = default;
 
     // Getters
-    [[nodiscard]] size_t GetPrgSize() const { return _prg_KiB_capacity; }
-    [[nodiscard]] size_t GetChrSize() const { return _chr_KiB_capacity; }
+    [[nodiscard]] size_t GetPrgBankCount() const { return _prg_rom_banks; }
+    [[nodiscard]] size_t GetChrBankCount() const { return _chr_rom_banks; }
 
     // Base methods
-    virtual u16                TranslateCPUAddress( u16 address ) = 0;
-    virtual u16                TranslatePPUAddress( u16 address ) = 0;
-    virtual void               HandleCPUWrite( u16 address, u8 data ) = 0;
-    [[nodiscard]] virtual u8   GetMirrorMode() = 0;
-    [[nodiscard]] virtual bool HasPrgRam() = 0;
+    virtual u32  TranslateCPUAddress( u16 address ) = 0;
+    virtual u32  TranslatePPUAddress( u16 address ) = 0;
+    virtual void HandleCPUWrite( u16 address, u8 data ) = 0;
+
+    [[nodiscard]] virtual bool SupportsPrgRam() = 0;
     [[nodiscard]] virtual bool HasExpansionRom() = 0;
     [[nodiscard]] virtual bool HasExpansionRam() = 0;
 
+    [[nodiscard]] virtual MirrorMode GetMirrorMode() = 0;
+
   private:
-    size_t _prg_KiB_capacity;
-    size_t _chr_KiB_capacity;
+    u8 _prg_rom_banks;
+    u8 _chr_rom_banks;
 };

--- a/include/mappers/mapper0.h
+++ b/include/mappers/mapper0.h
@@ -4,12 +4,14 @@
 class Mapper0 : public Mapper
 {
   public:
-    Mapper0( u16 prg_size, u16 chr_size ) : Mapper( prg_size, chr_size ) {}
-    auto               TranslateCPUAddress( u16 address ) -> u16 override;
-    auto               TranslatePPUAddress( u16 address ) -> u16 override;
-    void               HandleCPUWrite( u16 address, u8 data ) override;
-    [[nodiscard]] u8   GetMirrorMode() override { return 0; }
-    [[nodiscard]] bool HasPrgRam() override { return false; }
+    Mapper0( u8 prg_rom_banks, u8 chr_rom_banks ) : Mapper( prg_rom_banks, chr_rom_banks ) {}
+    auto TranslateCPUAddress( u16 address ) -> u32 override;
+    auto TranslatePPUAddress( u16 address ) -> u32 override;
+    void HandleCPUWrite( u16 address, u8 data ) override;
+
+    [[nodiscard]] bool SupportsPrgRam() override { return false; }
     [[nodiscard]] bool HasExpansionRom() override { return false; }
     [[nodiscard]] bool HasExpansionRam() override { return false; }
+
+    [[nodiscard]] MirrorMode GetMirrorMode() override { return MirrorMode::Horizontal; }
 };

--- a/include/mappers/mapper1.h
+++ b/include/mappers/mapper1.h
@@ -1,0 +1,38 @@
+#pragma once
+#include "mapper-base.h"
+
+class Mapper1 : public Mapper
+{
+
+  public:
+    Mapper1( u8 prg_rom_banks, u8 chr_rom_banks );
+    auto TranslateCPUAddress( u16 address ) -> u32 override;
+    auto TranslatePPUAddress( u16 address ) -> u32 override;
+    void HandleCPUWrite( u16 address, u8 data ) override;
+
+    [[nodiscard]] bool SupportsPrgRam() override { return true; }
+    [[nodiscard]] bool HasExpansionRom() override { return false; }
+    [[nodiscard]] bool HasExpansionRam() override { return false; }
+
+    [[nodiscard]] MirrorMode GetMirrorMode() override;
+
+  private:
+    u8 _control_register{ 0x1C };
+
+    // PRG bank selectors.
+    u8 _prg_bank_16_lo{ 0 };
+    u8 _prg_bank_16_hi;
+    u8 _prg_bank_32{ 0 };
+
+    // CHR bank selectors
+    u8 _chr_bank_4_lo{ 0 };
+    u8 _chr_bank_4_hi{ 0 };
+    u8 _chr_bank_8{ 0 };
+
+    // Serial loading mechanism
+    u8 _shift_register{ 0x10 };
+    u8 _write_count{ 0 };
+
+    // Mirroring
+    MirrorMode _mirror_mode{ MirrorMode::Horizontal };
+};

--- a/include/utils.h
+++ b/include/utils.h
@@ -1,10 +1,21 @@
 #pragma once
 
 #include "cpu.h"
+#include <regex>
 #include <string>
+#include <vector>
+
+using u8 = std::uint8_t;
+using u16 = std::uint16_t;
+using namespace std;
 
 namespace utils
 {
+
+using MatchResult = std::vector<std::string>;
+using MatchResults = std::vector<MatchResult>;
+MatchResult  parseLogLine( const std::string &line, const std::regex &pattern, std::size_t expectedMatches );
+MatchResults parseLog( const std::string &filename, const std::regex &pattern, std::size_t expectedMatches );
 
 inline std::string toHex( u16 num, u8 width = 4 )
 {

--- a/include/utils.h
+++ b/include/utils.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "cpu.h"
+#include <cstdint>
+#include <cstddef>
 #include <regex>
 #include <string>
 #include <vector>

--- a/src/bus.cpp
+++ b/src/bus.cpp
@@ -93,7 +93,4 @@ void Bus::Write( const u16 address, const u8 data )
     std::cout << "Unhandled write to address: " << std::hex << address << "\n";
 }
 
-void Bus::LoadCartridge( std::shared_ptr<Cartridge> cartridge )
-{
-    _cartridge = std::move( cartridge );
-}
+void Bus::LoadCartridge( std::shared_ptr<Cartridge> cartridge ) { _cartridge = std::move( cartridge ); }

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -4,6 +4,7 @@
 #include "cpu.h"
 #include "utils.h"
 #include <cstddef>
+#include <string>
 #include <iostream>
 #include <stdexcept>
 

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -353,7 +353,7 @@ u8 CPU::Fetch()
 void CPU::Tick()
 {
     // debug, print the instruction
-    // std::cout << DisassembleAtPC() << '\n';
+    // std::cout << LogLineAtPC() << '\n';
 
     // Fetch the next opcode and increment the program counter
     u8 const opcode = Fetch();
@@ -403,7 +403,7 @@ void CPU::Reset()
     _pc = Read( 0xFFFD ) << 8 | Read( 0xFFFC );
 }
 
-std::string CPU::DisassembleAtPC() // NOLINT
+std::string CPU::LogLineAtPC( bool verbose ) // NOLINT
 {
     /*
      * @brief Disassembles the instruction at the current program counter
@@ -415,8 +415,8 @@ std::string CPU::DisassembleAtPC() // NOLINT
     std::string const &name_addrmode = _opcodeTable[Read( _pc )].name;
     if ( name_addrmode.empty() )
     {
-        std::cerr << "Attempted to grab from a non existing table entry at PC: "
-                  << utils::toHex( _pc, 4 ) << '\n';
+        std::cerr << "Attempted to grab from a non existing table entry at PC: " << utils::toHex( _pc, 4 )
+                  << '\n';
         std::cerr << "Opcode: " << utils::toHex( Read( _pc ), 2 ) << '\n';
         // This is only used for debugging, so we can throw an exception
         throw std::runtime_error( "Invalid opcode" );
@@ -449,9 +449,10 @@ std::string CPU::DisassembleAtPC() // NOLINT
     ( name[0] == '*' ) ? output += "*" + name.substr( 1 ) + " " : output += name + " ";
 
     // Addressing mode and operand
-    u8 value = 0x00;
-    u8 low = 0x00;
-    u8 high = 0x00;
+    std::string assembly_str;
+    u8          value = 0x00;
+    u8          low = 0x00;
+    u8          high = 0x00;
     if ( addr_mode == "Implied" )
     {
         // Nothing to prefix
@@ -459,16 +460,16 @@ std::string CPU::DisassembleAtPC() // NOLINT
     else if ( addr_mode == "Immediate" )
     {
         value = Read( _pc + 1 );
-        output += "#$" + utils::toHex( value, 2 );
+        assembly_str += "#$" + utils::toHex( value, 2 );
     }
     else if ( addr_mode == "ZeroPage" || addr_mode == "ZeroPageX" || addr_mode == "ZeroPageY" )
     {
         value = Read( _pc + 1 );
-        output += "$" + utils::toHex( value, 2 );
+        assembly_str += "$" + utils::toHex( value, 2 );
 
-        ( addr_mode == "ZeroPageX" )   ? output += ", X"
-        : ( addr_mode == "ZeroPageY" ) ? output += ", Y"
-                                       : output += "";
+        ( addr_mode == "ZeroPageX" )   ? assembly_str += ", X"
+        : ( addr_mode == "ZeroPageY" ) ? assembly_str += ", Y"
+                                       : assembly_str += "";
     }
     else if ( addr_mode == "Absolute" || addr_mode == "AbsoluteX" || addr_mode == "AbsoluteY" )
     {
@@ -476,23 +477,23 @@ std::string CPU::DisassembleAtPC() // NOLINT
         high = Read( _pc + 2 );
         u16 const address = ( high << 8 ) | low;
 
-        output += "$" + utils::toHex( address, 4 );
-        ( addr_mode == "AbsoluteX" )   ? output += ", X"
-        : ( addr_mode == "AbsoluteY" ) ? output += ", Y"
-                                       : output += "";
+        assembly_str += "$" + utils::toHex( address, 4 );
+        ( addr_mode == "AbsoluteX" )   ? assembly_str += ", X"
+        : ( addr_mode == "AbsoluteY" ) ? assembly_str += ", Y"
+                                       : assembly_str += "";
     }
     else if ( addr_mode == "Indirect" )
     {
         low = Read( _pc + 1 );
         high = Read( _pc + 2 );
         u16 const address = ( high << 8 ) | low;
-        output += "($" + utils::toHex( address, 4 ) + ")";
+        assembly_str += "($" + utils::toHex( address, 4 ) + ")";
     }
     else if ( addr_mode == "IndirectX" || addr_mode == "IndirectY" )
     {
         value = Read( _pc + 1 );
-        ( addr_mode == "IndirectX" ) ? output += "($" + utils::toHex( value, 2 ) + ", X)"
-                                     : output += "($" + utils::toHex( value, 2 ) + "), Y";
+        ( addr_mode == "IndirectX" ) ? assembly_str += "($" + utils::toHex( value, 2 ) + ", X)"
+                                     : assembly_str += "($" + utils::toHex( value, 2 ) + "), Y";
     }
     else if ( addr_mode == "Relative" )
     {
@@ -500,12 +501,48 @@ std::string CPU::DisassembleAtPC() // NOLINT
         s8 const  offset = static_cast<s8>( value );
         u16 const address = _pc + 2 + offset;
 
-        output += "$" + utils::toHex( value, 2 ) + " [$" + utils::toHex( address, 4 ) + "]";
+        assembly_str += "$" + utils::toHex( value, 2 ) + " [$" + utils::toHex( address, 4 ) + "]";
     }
     else
     {
         // Houston.. yet again
         throw std::runtime_error( "Unknown addressing mode: " + addr_mode );
+    }
+    // Pad the assembly string with spaces, for fixed length
+
+    output += assembly_str + std::string( 15 - assembly_str.size(), ' ' );
+
+    // Add more log info
+    if ( verbose )
+    {
+        std::string registers_str;
+        // Format
+        // a: 00 x: 00 y: 00 s: FD
+        registers_str += "a: " + utils::toHex( _a, 2 ) + " ";
+        registers_str += "x: " + utils::toHex( _x, 2 ) + " ";
+        registers_str += "y: " + utils::toHex( _y, 2 ) + " ";
+        registers_str += "s: " + utils::toHex( _s, 2 ) + " ";
+
+        // status register
+        // Will return a formatted status string
+        // p: hex value, status string (NV-BDIZC). Letter present is flag set, dash is flag unset
+        std::string status_str;
+        status_str += "p: " + utils::toHex( _p, 2 ) + "  ";
+
+        std::string status_flags = "NV-BDIZC";
+        std::string status_flags_lower = "nv-bdizc";
+        std::string status_flags_str;
+        for ( int i = 7; i >= 0; i-- )
+        {
+            status_flags_str += ( _p & ( 1 << i ) ) != 0 ? status_flags[7 - i] : status_flags_lower[7 - i];
+        }
+        status_str += status_flags_str;
+
+        // Combine to the output string
+        output += registers_str + status_str;
+
+        // cycle count
+        output += "  Cycle: " + std::to_string( _cycles );
     }
     return output;
 }
@@ -850,8 +887,7 @@ void CPU::CompareAddressWithRegister( u16 address, u8 reg )
 
     // Set negative flag if the result is negative,
     // i.e. the sign bit is set
-    ( ( reg - value ) & 0b10000000 ) != 0 ? SetFlags( Status::Negative )
-                                          : ClearFlags( Status::Negative );
+    ( ( reg - value ) & 0b10000000 ) != 0 ? SetFlags( Status::Negative ) : ClearFlags( Status::Negative );
 
     // Set the carry flag if the reg >= value
     ( reg >= value ) ? SetFlags( Status::Carry ) : ClearFlags( Status::Carry );

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,8 +14,8 @@ int main()
         return 1;
     }
 
-    SDL_Window *window = SDL_CreateWindow( "NES Emulator", SDL_WINDOWPOS_CENTERED,
-                                           SDL_WINDOWPOS_CENTERED, 512, 480, SDL_WINDOW_SHOWN );
+    SDL_Window *window = SDL_CreateWindow( "NES Emulator", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
+                                           512, 480, SDL_WINDOW_SHOWN );
 
     if ( window == nullptr )
     {

--- a/src/mappers/mapper0.cpp
+++ b/src/mappers/mapper0.cpp
@@ -1,9 +1,8 @@
 #include "mappers/mapper-base.h"
 #include "mappers/mapper0.h"
-#include <cstddef>
 #include <stdexcept>
 
-[[nodiscard]] u16 Mapper0::TranslateCPUAddress( u16 address )
+[[nodiscard]] u32 Mapper0::TranslateCPUAddress( u16 address )
 {
     /**
      * @brief Cartridges with Mapper 0 come in two fixed sizes: 16 KiB and 32 KiB
@@ -13,14 +12,14 @@
     if ( address >= 0x8000 && address <= 0xFFFF )
     {
         // 32 KiB PRG ROM
-        if ( GetPrgSize() == static_cast<size_t>( 32 * 1024 ) )
+        if ( GetPrgBankCount() == 2 )
         {
             // Map directly to PRG ROM, starting at 0x0000
             return address - 0x8000;
         }
 
         // 16 KiB PRG ROM
-        if ( GetPrgSize() == static_cast<size_t>( 16 * 1024 ) )
+        if ( GetPrgBankCount() == 1 )
         {
             // Map to 0, with mirroring after 16 KiB
             return ( address - 0x8000 ) % ( 16 * 1024 );
@@ -32,7 +31,7 @@
     throw std::runtime_error( "Address out of range in TranslateCPUAddress" );
 }
 
-[[nodiscard]] auto Mapper0::TranslatePPUAddress( u16 address ) -> u16
+[[nodiscard]] auto Mapper0::TranslatePPUAddress( u16 address ) -> u32
 {
     /**
      * @brief Translate PPU address. Mapper 0 doesn't redirect PPU address in any way

--- a/src/mappers/mapper1.cpp
+++ b/src/mappers/mapper1.cpp
@@ -1,0 +1,283 @@
+#include "mappers/mapper1.h"
+#include "mappers/mapper-base.h"
+#include <stdexcept>
+
+Mapper1::Mapper1( u8 prg_rom_banks, u8 chr_rom_banks )
+    : Mapper( prg_rom_banks, chr_rom_banks ), _prg_bank_16_hi( prg_rom_banks - 1 )
+
+{
+}
+
+MirrorMode Mapper1::GetMirrorMode() { return _mirror_mode; }
+
+/*
+################################
+||                            ||
+||          CPU Read          ||
+||                            ||
+################################
+*/
+[[nodiscard]] u32 Mapper1::TranslateCPUAddress( u16 address )
+{
+    /**
+     * @details
+     * PRG bank selectors point to individual 16 KiB banks within the PRG ROM.
+     * The total number of banks is derived from the 4th byte of the NES ROM header,
+     * which specifies the size of the PRG ROM in 16 KiB units. For example, if the
+     * cartridge provides 4 PRG banks (64 KiB total), the selectors operate as follows:
+     *
+     * - **32 KiB Mode** (determined by the control register):
+     *   - `_prg_bank_32 = 0`:
+     *     - Bank 0 (16 KiB) is mapped to `0x8000–0xBFFF`.
+     *     - Bank 1 (16 KiB) is mapped to `0xC000–0xFFFF`.
+     *   - `_prg_bank_32 = 1`:
+     *     - Bank 2 (16 KiB) is mapped to `0x8000–0xBFFF`.
+     *     - Bank 3 (16 KiB) is mapped to `0xC000–0xFFFF`.
+     *
+     * - **16 KiB Mode** (determined by the control register):
+     *   - `_prg_bank_16_lo` selects the bank for `0x8000–0xBFFF`.
+     *   - `_prg_bank_16_hi` selects the bank for `0xC000–0xFFFF`.
+     *
+     *   Example Configurations:
+     *   - `_prg_bank_16_lo = 0`, `_prg_bank_16_hi = 3`:
+     *     - Bank 0 (16 KiB) is mapped to `0x8000–0xBFFF`.
+     *     - Bank 3 (16 KiB) is mapped to `0xC000–0xFFFF`.
+     *   - `_prg_bank_16_lo = 2`, `_prg_bank_16_hi = 3`:
+     *     - Bank 2 (16 KiB) is mapped to `0x8000–0xBFFF`.
+     *     - Bank 3 (16 KiB) is mapped to `0xC000–0xFFFF`.
+     *
+     * In 16 KiB mode, `_prg_bank_16_lo` and `_prg_bank_16_hi` independently select
+     * banks for their respective address ranges, allowing finer-grained control.
+     *
+     * Mapper 1 uses these selectors dynamically, based on writes to the mapper's
+     * internal registers, to swap PRG ROM banks as needed during gameplay.
+     */
+
+    // 16 KiB mode
+    if ( ( _control_register & 0b00001000 ) != 0 )
+    {
+        if ( address >= 0x8000 && address <= 0xBFFF )
+        {
+            // Swap out the lower 16 KiB bank.
+            u32 const bank_offset = _prg_bank_16_lo * 0x4000;
+            return bank_offset + ( address & 0x3FFF );
+        }
+        if ( address >= 0xC000 && address <= 0xFFFF )
+        {
+            // Swap out the upper 16 KiB bank.
+
+            u32 const bank_offset = _prg_bank_16_hi * 0x4000;
+            return bank_offset + ( address & 0x3FFF );
+        }
+    }
+
+    // 32 KiB mode
+    u32 const bank_offset = _prg_bank_32 * 0x8000;
+    return bank_offset + ( address & 0x7FFF );
+}
+
+/*
+################################
+||                            ||
+||          CPU Write         ||
+||                            ||
+################################
+*/
+void Mapper1::HandleCPUWrite( u16 address, u8 data )
+{
+    /** @brief Handle writes to signal bank swapping
+     * @details
+     * ROM is normally read-only, but mapper 1 (and other mappers)
+     * use writes to change the bank selection in the cartridge.
+     */
+
+    // Reset state when data with the MSB set is written
+    if ( ( data & 0b10000000 ) != 0 )
+    {
+        _shift_register = 0x00;
+        _write_count = 0;
+        _control_register |= 0b00001100;
+        return;
+    }
+
+    // Serial loading mechanism
+    /* The Mapper 1 serial loading mechanism accumulates 5 writes.
+     . Each write shifts the register to the right and inserts the
+     * least significant bit (LSB) of the data byte into the most significant bit (MSB)
+     * position (bit 4).
+     *
+     * After 5 writes, the accumulated 5-bit value in `_shift_register` is applied to one
+     * of the mapper's registers. The target register is determined by examining bits 13
+     * and 14 of the write address. Additional information is encoded in the address, but only
+     * for the 5th write:
+     *
+     *   - 0x8000 – 0x9FFF: Configures mirroring mode, PRG banking mode, and CHR banking mode.
+     *   - 0xA000 – 0xBFFF: Selects the lower CHR bank.
+     *   - 0xC000 – 0xDFFF: Selects the upper CHR bank (in 4 KB mode).
+     *   - 0xE000 – 0xFFFF: Selects the PRG bank(s) to map to the CPU address space.
+     *
+     * Once the 5-bit value is applied to the selected register, the shift register and
+     * the write count are reset to prepare for the next sequence.
+     */
+    _shift_register >>= 1;
+    _shift_register |= ( data & 0b00000001 ) << 4;
+    _write_count++;
+    if ( !( _write_count == 5 ) )
+    {
+        return;
+    }
+
+    // On the fifth write, target register is derived from
+    // byte 13 and 14 of the address
+    u8 const target_register = ( address >> 13 ) & 0b00000011;
+
+    if ( target_register == 0 ) // 0x8000-0x9FFF
+    {
+        // Set control register to the first 5 bits of the shift register
+        _control_register = _shift_register & 0b00011111;
+
+        // the lower 2 bits of the control register set the mirroring mode
+        switch ( _control_register & 0b00000011 )
+        {
+            case 0x00:
+                _mirror_mode = MirrorMode::SingleLower;
+                break;
+            case 0x01:
+                _mirror_mode = MirrorMode::SingleUpper;
+                break;
+            case 0x02:
+                _mirror_mode = MirrorMode::Vertical;
+                break;
+            case 0x03:
+                _mirror_mode = MirrorMode::Horizontal;
+                break;
+            default:
+                throw std::runtime_error( "Invalid mirroring mode" );
+        }
+    }
+
+    else if ( target_register == 1 ) // 0xA000-0xBFFF
+    {
+        // Determine CHR banking mode (4 KiB or 8 KiB) based on bit 4 of the control register
+        bool const is_4_kb_chr_mode = ( _control_register & 0b00010000 ) != 0;
+
+        if ( is_4_kb_chr_mode )
+        {
+            // Set lower 4 KB CHR bank
+
+            // In 4 KiB mode, the shift register IS the bank index. The shift register is 5 bits
+            // wide, and all 5 bits are used to set the bank index directly. Masking ensures only
+            // the lower 5 bits are considered, as `_shift_register` is declared as a u8, and the
+            // upper 3 bits are always 0. The `bank_index` determines which 4 KiB CHR bank is mapped
+            // to the PPU address space (0x0000–0x0FFF for lower 4 KiB or 0x1000–0x1FFF for upper 4
+            // KiB).
+            u8 const bank_index = _shift_register & 0b00011111; // Indeces: 0 - 31
+            _chr_bank_4_lo = bank_index;
+        }
+        else
+        {
+            // Set 8 KB CHR bank
+            // In 8 KiB, all indeces must start on an even number, other wise the 8 KiB bank will
+            // be misaligned. Hence, the mask captures the shift register but clears out the 1 that
+            // would have otherwise made the index odd
+            u8 const bank_index = _shift_register & 0b00011110; // Indeces 0 - 30, even numbers only
+            _chr_bank_8 = bank_index;
+        }
+    }
+    else if ( target_register == 2 ) // 0xC000-0xDFFF
+    {
+        bool const is_4_kb_chr_mode = ( _control_register & 0b00010000 ) != 0;
+        if ( is_4_kb_chr_mode )
+        {
+            // Set upper 4 KB CHR bank
+            u8 const bank_index = _shift_register & 0b00011111;
+            _chr_bank_4_hi = bank_index;
+        }
+        // No 8 KiB mode for this target range
+    }
+    else if ( target_register == 3 ) // 0xE000-0xFFFF
+    {
+        // PRG banks
+        u8 const prg_bank_mode = ( _control_register >> 2 ) & 0b00000011;
+
+        if ( prg_bank_mode == 0 || prg_bank_mode == 1 )
+        {
+            // Set the 32 KiB prg bank
+
+            // The masking logic first masks the shift register against 0xE,
+            // which provides a range of even values from 0 to 14
+            // It shifts this result right by 1, which is equivalent to dividing by 2
+            // giving the final bank ranges from 0 to 7
+            u8 const bank_index = ( _shift_register & 0b00001110 ) >> 1;
+            _prg_bank_32 = bank_index;
+        }
+        else if ( prg_bank_mode == 2 )
+        {
+            // 16 KiB mode
+
+            // The lower bank is fixed to 0
+            _prg_bank_16_lo = 0;
+
+            // The high bank is derived from the lower 4 bits of the shift register,
+            // giving it a range from 0 to 15
+            _prg_bank_16_hi = _shift_register & 0b00001111;
+        }
+        else if ( prg_bank_mode == 3 )
+        {
+            // 16 KiB mode
+
+            // The lower bank is derived from the lower 4 bits of the shift register, ranges from 0
+            // to 15
+            _prg_bank_16_lo = _shift_register & 0b00001111;
+
+            // the high bank is fixed to the last bank
+            _prg_bank_16_hi = GetPrgBankCount() - 1;
+        }
+    }
+
+    // Reset the shift register and write count
+    _shift_register = 0;
+    _write_count = 0;
+}
+
+/*
+################################
+||                            ||
+||          PPU Read          ||
+||                            ||
+################################
+*/
+[[nodiscard]] u32 Mapper1::TranslatePPUAddress( u16 address )
+{
+    // If no chr rom banks, the address is directly mapped
+    if ( GetChrBankCount() == 0 )
+    {
+        return address;
+    }
+
+    bool const is_4_kb_chr_mode = ( _control_register & 0b10000 ) != 0;
+    if ( is_4_kb_chr_mode )
+    {
+        // 4 KiB, read the lower 4 KiB bank
+        if ( address >= 0x0000 && address <= 0x0FFF )
+        {
+            const u32 bank_offset = _chr_bank_4_lo * 0x1000;
+            return bank_offset + ( address & 0x0FFF );
+        }
+        // 4 KiB, read the upper 4 KiB bank
+        if ( address >= 0x1000 && address <= 0x1FFF )
+        {
+            const u32 bank_offset = _chr_bank_4_hi * 0x1000;
+            return bank_offset + ( address & 0x0FFF );
+        }
+    }
+    else
+    {
+        // 8 KiB, read the 8 KiB bank
+        const u32 bank_offset = _chr_bank_8 * 0x2000;
+        return bank_offset + ( address & 0x1FFF );
+    }
+
+    // Shouldn't make it here.
+    return 0xFF;
+}

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,0 +1,72 @@
+#include "utils.h"
+#include <fstream>
+#include <stdexcept>
+
+/*
+################################
+||                            ||
+||      Regex log parsers     ||
+||                            ||
+################################
+* Helper function that takes a regex match
+* and returns a CPU state struct, based on the match
+* Used on CPU output logs from other emulators. The logs are in different
+* formats, but the general information we want from them is the same
+*
+*/
+
+namespace utils
+{
+MatchResult parseLogLine( const string &line, const regex &pattern, size_t expectedMatches )
+{
+    smatch      match;
+    MatchResult fields;
+
+    if ( regex_match( line, match, pattern ) )
+    {
+        if ( match.size() < expectedMatches )
+        {
+            throw runtime_error( "Not enough groups found in the line." );
+        }
+        // Skip match[0], which is the entire match.
+        for ( size_t i = 1; i < match.size(); ++i )
+        {
+            fields.push_back( match[i].str() );
+        }
+    }
+    else
+    {
+        throw runtime_error( "Regex did not match line: " + line );
+    }
+    return fields;
+}
+
+MatchResults parseLog( const string &filename, const regex &pattern, size_t expectedMatches )
+{
+    MatchResults matches;
+
+    ifstream log( filename );
+    if ( !log.is_open() )
+    {
+        throw runtime_error( "utils::parseLog:Error opening file: " + filename );
+    }
+
+    string line;
+    size_t line_num = 0;
+    while ( getline( log, line ) )
+    {
+        try
+        {
+            matches.push_back( parseLogLine( line, pattern, expectedMatches ) );
+        }
+        catch ( const exception &e )
+        {
+            throw runtime_error( "utils::parseLog:Error parsing line " + to_string( line_num ) + ": " +
+                                 e.what() );
+        }
+        ++line_num;
+    }
+
+    return matches;
+}
+} // namespace utils

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,6 +1,10 @@
 #include "utils.h"
+#include <cstddef>
+#include <exception>
 #include <fstream>
+#include <regex>
 #include <stdexcept>
+#include <string>
 
 /*
 ################################

--- a/tests/rom_test.cpp
+++ b/tests/rom_test.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include "bus.h"
 #include "cpu.h"
+#include "utils.h"
 #include "cartridge.h"
 #include <fstream>
 #include <regex>
@@ -9,30 +10,6 @@
 #include <memory>
 using namespace std;
 
-auto toHex( uint32_t num, uint8_t width ) -> string
-{
-    string     hex_str( width, '0' );
-    const char hex_chars[] = "0123456789ABCDEF";
-    for ( int i = width - 1; i >= 0; --i, num >>= 4 )
-    {
-        hex_str[i] = hex_chars[num & 0xF];
-    }
-    return hex_str;
-}
-
-// Structure to hold expected CPU state from the log
-struct ExpectedLine
-{
-    uint16_t        address;
-    vector<uint8_t> opcode; // Changed to vector to handle multiple opcode bytes
-    uint8_t         a;
-    uint8_t         x;
-    uint8_t         y;
-    uint8_t         p;
-    uint8_t         sp;
-    uint64_t        cycles;
-};
-
 /*
 ################################################
 ||                                            ||
@@ -40,6 +17,7 @@ struct ExpectedLine
 ||                                            ||
 ################################################
 */
+
 TEST( RomTests, Nestest )
 {
     Bus bus;
@@ -53,103 +31,61 @@ TEST( RomTests, Nestest )
 
     cpu.Reset();
 
-    // Open the log file for writing disassembly data
-    ofstream log( "tests/output/my_nestest-log.txt" );
-    if ( !log.is_open() )
+    // Open the log file for writing output data
+    ofstream actual_output( "tests/output/my_nestest-log.txt" );
+
+    // color codes
+    const std::string red = "\033[31m";
+    const std::string reset = "\033[0m";
+
+    if ( !actual_output.is_open() )
     {
         cerr << "Failed to open output/my_nestest-log.txt for writing\n";
         FAIL() << "Cannot open log file.";
         return;
     }
 
-    // Open the nestest.log file for reading expected CPU states
-    ifstream nestest_log( "tests/logs/nestest-log.txt" );
-    if ( !nestest_log.is_open() )
-    {
-        cerr << "Failed to open nestest-log.txt for reading\n";
-        FAIL() << "Cannot open nestest log file.";
-        return;
-    }
-
-    // Define a bit of regex magic to grab groups of hex bytes
-    regex line_pattern(
-        R"(^([A-F0-9]{4})\s+([A-F0-9]{2})\s.{39}A:([A-F0-9]{2})\s*X:([A-F0-9]{2})\s*Y:([A-F0-9]{2})\s*P:([A-F0-9]{2})\s*SP:([A-F0-9]{2})\s*.{12}CYC:(\d+))",
+    // Pattern for nestest log output
+    regex pattern(
+        R"(^([A-F0-9]{4}).*?A:([A-F0-9]{2}).*?X:([A-F0-9]{2}).*?Y:([A-F0-9]{2}).*?P:([A-F0-9]{2}).*?SP:([A-F0-9]{2}).*?,\s*(\d+).*?CYC:(\d+))",
         regex_constants::ECMAScript );
 
-    // Read in the expected lines into a vector, which we will use to compare against our own
-    // execution
-    vector<ExpectedLine> expected_lines;
+    utils::MatchResults matches = utils::parseLog( "tests/logs/nestest-log.txt", pattern, 8 );
 
-    string line;
-    size_t line_number = 0;
-    while ( getline( nestest_log, line ) )
+    struct NestestLogInfo
     {
-        ++line_number;
-        smatch match;
-        // here comes the regex magic
-        if ( regex_match( line, match, line_pattern ) )
-        {
-            try
-            {
-                if ( match.size() != 9 )
-                {
-                    throw runtime_error( "Regex groups missing data" );
-                }
-
-                // Address
-                ExpectedLine entry{};
-                entry.address = static_cast<uint16_t>( stoul( match[1].str(), nullptr, 16 ) );
-
-                // Parse opcode bytes
-                vector<uint8_t> opcode_bytes;
-                istringstream   opcode_stream( match[2].str() );
-                string          byte_str;
-                while ( opcode_stream >> byte_str )
-                {
-                    uint8_t byte = static_cast<uint8_t>( stoul( byte_str, nullptr, 16 ) );
-                    opcode_bytes.push_back( byte );
-                }
-                entry.opcode = opcode_bytes;
-
-                // Registers and the rest of the data
-                entry.a = static_cast<uint8_t>( stoul( match[3].str(), nullptr, 16 ) );
-                entry.x = static_cast<uint8_t>( stoul( match[4].str(), nullptr, 16 ) );
-                entry.y = static_cast<uint8_t>( stoul( match[5].str(), nullptr, 16 ) );
-                entry.p = static_cast<uint8_t>( stoul( match[6].str(), nullptr, 16 ) );
-                entry.sp = static_cast<uint8_t>( stoul( match[7].str(), nullptr, 16 ) );
-                entry.cycles = static_cast<uint64_t>( stoul( match[8].str(), nullptr, 10 ) );
-
-                expected_lines.push_back( entry );
-            }
-            catch ( const exception &e )
-            {
-                cerr << "Failed to parse line " << line_number << ": " << line
-                     << "\nException: " << e.what() << '\n';
-                FAIL() << "Parsing failed at line " << line_number;
-                return;
-            }
-        }
-        else
-        {
-            cerr << "Regex did not match line " << line_number << ": " << line << '\n';
-        }
-    }
-
-    if ( expected_lines.empty() )
+        u16 pc;
+        u8  a;
+        u8  x;
+        u8  y;
+        u8  p;
+        u8  sp;
+        // s16 ppu_cycles;
+        u64 cpu_cycles;
+    };
+    std::vector<NestestLogInfo> expected_lines;
+    for ( const auto &match : matches )
     {
-        std::cerr << "No expected lines were parsed. Check your regex and input file.\n";
-        FAIL() << "No parsed lines.";
-        return;
+        NestestLogInfo entry{};
+        entry.pc = static_cast<u16>( stoul( match[0], nullptr, 16 ) );
+        entry.a = static_cast<u8>( stoul( match[1], nullptr, 16 ) );
+        entry.x = static_cast<u8>( stoul( match[2], nullptr, 16 ) );
+        entry.y = static_cast<u8>( stoul( match[3], nullptr, 16 ) );
+        entry.p = static_cast<u8>( stoul( match[4], nullptr, 16 ) );
+        entry.sp = static_cast<u8>( stoul( match[5], nullptr, 16 ) );
+        // entry.ppu_cycles = static_cast<s16>( stoul( match[6], nullptr, 10 ) );
+        entry.cpu_cycles = stoull( match[7], nullptr, 10 );
+        expected_lines.push_back( entry );
     }
 
     // Initialize CPU state with the first expected entry
-    cpu.SetProgramCounter( expected_lines[0].address );
+    cpu.SetProgramCounter( expected_lines[0].pc );
     cpu.SetAccumulator( expected_lines[0].a );
     cpu.SetXRegister( expected_lines[0].x );
     cpu.SetYRegister( expected_lines[0].y );
     cpu.SetStatusRegister( expected_lines[0].p );
     cpu.SetStackPointer( expected_lines[0].sp );
-    cpu.SetCycles( expected_lines[0].cycles );
+    cpu.SetCycles( expected_lines[0].cpu_cycles );
 
     size_t line_index = 0;
     bool   did_fail = false;
@@ -159,72 +95,87 @@ TEST( RomTests, Nestest )
     while ( line_index < expected_lines.size() )
     {
         // Save output to our own log file
-        log << cpu.DisassembleAtPC() << '\n';
+        actual_output << cpu.LogLineAtPC() << '\n';
 
         // Get the expected line
         const auto &expected = expected_lines[line_index];
 
         // Compare all the relevant values with expected
 
-        if ( cpu.GetProgramCounter() != expected.address )
+        if ( cpu.GetProgramCounter() != expected.pc )
         {
             did_fail = true;
-            cerr << ( line_index + 1 ) << ": PC mismatch\n";
-            cerr << "Expected: " << toHex( expected.address, 4 ) << "    "
-                 << "Actual: " << toHex( cpu.GetProgramCounter(), 4 ) << '\n';
+            cerr << '\n';
+            cerr << red << ( line_index + 1 ) << ": PC mismatch\n" << reset;
+            cerr << "Expected: " << utils::toHex( expected.pc, 4 ) << "    "
+                 << "Actual: " << utils::toHex( cpu.GetProgramCounter(), 4 ) << '\n';
+            cerr << '\n';
         }
 
         if ( cpu.GetAccumulator() != expected.a )
         {
             did_fail = true;
-            std::cerr << ( line_index + 1 ) << ": A mismatch\n";
-            std::cerr << "Expected: " << toHex( expected.a, 2 ) << "    "
-                      << "Actual: " << toHex( cpu.GetAccumulator(), 2 ) << '\n';
+            cerr << '\n';
+            std::cerr << red << ( line_index + 1 ) << ": A mismatch\n" << reset;
+            std::cerr << "Expected: " << utils::toHex( expected.a, 2 ) << "    "
+                      << "Actual: " << utils::toHex( cpu.GetAccumulator(), 2 ) << '\n';
+            cerr << '\n';
         }
 
         if ( cpu.GetXRegister() != expected.x )
         {
             did_fail = true;
-            std::cerr << ( line_index + 1 ) << ": X mismatch\n";
-            std::cerr << "Expected: " << toHex( expected.x, 2 ) << "    "
-                      << "Actual: " << toHex( cpu.GetXRegister(), 2 ) << '\n';
+            cerr << '\n';
+            std::cerr << red << ( line_index + 1 ) << ": X mismatch\n" << reset;
+            std::cerr << "Expected: " << utils::toHex( expected.x, 2 ) << "    "
+                      << "Actual: " << utils::toHex( cpu.GetXRegister(), 2 ) << '\n';
+            cerr << '\n';
         }
 
         if ( cpu.GetYRegister() != expected.y )
         {
             did_fail = true;
-            std::cerr << ( line_index + 1 ) << ": Y mismatch\n";
-            std::cerr << "Expected: " << toHex( expected.y, 2 ) << "    "
-                      << "Actual: " << toHex( cpu.GetYRegister(), 2 ) << '\n';
+            cerr << '\n';
+            std::cerr << red << ( line_index + 1 ) << ": Y mismatch\n" << reset;
+            std::cerr << "Expected: " << utils::toHex( expected.y, 2 ) << "    "
+                      << "Actual: " << utils::toHex( cpu.GetYRegister(), 2 ) << '\n';
+            cerr << '\n';
         }
 
         if ( cpu.GetStatusRegister() != expected.p )
         {
             did_fail = true;
-            std::cerr << ( line_index + 1 ) << ": P mismatch\n";
-            std::cerr << "Expected: " << toHex( expected.p, 2 ) << "    "
-                      << "Actual: " << toHex( cpu.GetStatusRegister(), 2 ) << '\n';
+            cerr << '\n';
+            std::cerr << red << ( line_index + 1 ) << ": P mismatch\n" << reset;
+            std::cerr << "Expected: " << utils::toHex( expected.p, 2 ) << "    "
+                      << "Actual: " << utils::toHex( cpu.GetStatusRegister(), 2 ) << '\n';
+            cerr << '\n';
         }
 
         if ( cpu.GetStackPointer() != expected.sp )
         {
             did_fail = true;
-            std::cerr << ( line_index + 1 ) << ": SP mismatch\n";
-            std::cerr << "Expected: " << toHex( expected.sp, 2 ) << "    "
-                      << "Actual: " << toHex( cpu.GetStackPointer(), 2 ) << '\n';
+            cerr << '\n';
+            std::cerr << red << ( line_index + 1 ) << ": SP mismatch\n" << reset;
+            std::cerr << "Expected: " << utils::toHex( expected.sp, 2 ) << "    "
+                      << "Actual: " << utils::toHex( cpu.GetStackPointer(), 2 ) << '\n';
+            cerr << '\n';
         }
 
-        if ( cpu.GetCycles() != expected.cycles )
+        if ( cpu.GetCycles() != expected.cpu_cycles )
         {
             did_fail = true;
-            std::cerr << ( line_index + 1 ) << ": Cycles mismatch\n";
-            std::cerr << "Expected: " << expected.cycles << "    "
+            cerr << '\n';
+            std::cerr << red << ( line_index + 1 ) << ": Cycles mismatch\n" << reset;
+            std::cerr << "Expected: " << expected.cpu_cycles << "    "
                       << "Actual: " << cpu.GetCycles() << '\n';
+            cerr << '\n';
         }
 
         if ( did_fail )
         {
-            FAIL() << "Mismatch detected at line " << ( line_index + 1 );
+
+            FAIL() << red << "Mismatch detected at line " << ( line_index + 1 ) << reset;
             break;
         }
 
@@ -232,14 +183,16 @@ TEST( RomTests, Nestest )
         line_index++;
     }
 
-    if ( !did_fail )
+    if ( did_fail )
     {
-        std::cout << "Nestest passed.\n";
+        std::cerr << red << "Nestest failed.\n" << reset;
     }
     else
     {
-        std::cerr << "Nestest failed.\n";
+
+        std::string green = "\033[32m";
+        std::cout << green << "Nestest passed.\n" << reset;
     }
 
-    log.close();
+    actual_output.close();
 }


### PR DESCRIPTION
Closes #76

Implemented support for Mapper 1 with bank switching. I left a lot of comments in the implementation, so take a look if you're curious about what it does. We won't be able to test it until we finish all the opcodes, but I've tested it on my personal emulator, which is slightly ahead of ours. 

Here's a summary of the changes

- Renamed `DisassembleAtPC` to `LogLineAtPC`, and it now has an optional verbose mode, to show additional information
- Increased the maximum line length from 100 to 110 in `.clang-format`
- Mappers now take bank counts instead of size in their constructors
- Added a regex helper function to help parse output logs based on a regex pattern, for testing our output against trusted logs
