### PR TITLE
Ppu Foundation

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -15,6 +15,10 @@ Checks: >
   ,-cppcoreguidelines-pro-bounds-constant-array-index
   ,readability-identifier-naming
   ,-readability-avoid-nested-conditional-operator
+  ,-readability-implicit-bool-conversion
+  ,-misc-non-private-member-variables-in-classes
+  ,-cppcoreguidelines-non-private-member-variables-in-classes
+  ,-cppcoreguidelines-pro-type-union-access
 CheckOptions:
   # Standardized naming conventions:
   - key: readability-identifier-naming.ClassCase

--- a/include/bus.h
+++ b/include/bus.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "cpu.h"
+#include "ppu.h"
 #include <array>
 #include <cstdint>
 #include <memory>
@@ -7,42 +8,64 @@
 using u8 = uint8_t;
 using u16 = uint16_t;
 using u64 = uint64_t;
+using s16 = int16_t;
 
-// forward declarations
 class Cartridge;
+class CPU;
 class PPU;
 class APU;
 
 class Bus
 {
   public:
-    // Will eventually pass other components to the constructor
-    // Bus( PPU &ppu, APU &apu, bool use_flat_memory = false );
-
     // Initialized with flat memory disabled by default. Enabled in json tests only
-    Bus( PPU *ppu, bool use_flat_memory = false );
+    Bus( bool use_flat_memory = false );
 
-    // Memory read/write interface
-    [[nodiscard]] u8 Read( uint16_t address ) const;
+    /*
+    ################################
+    ||         Peripherals        ||
+    ################################
+    */
+    CPU                        cpu;
+    PPU                        ppu;
+    std::shared_ptr<Cartridge> cartridge;
+
+    /*
+    ################################
+    ||         Bus Methods        ||
+    ################################
+    */
+    [[nodiscard]] u8 Read( uint16_t address );
     void             Write( u16 address, u8 data );
+    void             LoadCartridge( std::shared_ptr<Cartridge> cartridge );
 
-    // Load or change the cartridge during runtime
-    void LoadCartridge( std::shared_ptr<Cartridge> cartridge );
+    /*
+    ################################
+    ||        Debug Methods       ||
+    ################################
+    */
+    [[nodiscard]] bool IsTestMode() const;
 
   private:
-    // Shared ownership for dynamic life cycle management, leave off for now
-    std::shared_ptr<Cartridge> _cartridge;
+    /*
+    ################################
+    ||           CPU RAM          ||
+    ################################
+    */
+    std::array<u8, 0x0800> _ram{}; // 2KB internal cpu RAM
 
-    // APU and PPU stubs
-    PPU *_ppu;
-
-    // Flat memory for early implementation
+    /*
+    ################################
+    ||       Debug Variables      ||
+    ################################
+    */
     bool                  _use_flat_memory; // For testing purposes
     std::array<u8, 65536> _flat_memory{};   // 64KB memory, for early testing
 
-    // CPU RAM, this can stay in this file
-    std::array<u8, 0x0800> _ram{}; // 2KB internal cpu RAM
-
-    // Stubs
+    /*
+    ################################
+    ||       Temporary Stubs      ||
+    ################################
+    */
     std::array<u8, 0x0020> _apu_io_memory{}; // 32 bytes APU and I/O registers
 };

--- a/include/mappers/mapper0.h
+++ b/include/mappers/mapper0.h
@@ -13,5 +13,5 @@ class Mapper0 : public Mapper
     [[nodiscard]] bool HasExpansionRom() override { return false; }
     [[nodiscard]] bool HasExpansionRam() override { return false; }
 
-    [[nodiscard]] MirrorMode GetMirrorMode() override { return MirrorMode::Horizontal; }
+    [[nodiscard]] MirrorMode GetMirrorMode() override { return MirrorMode::Vertical; }
 };

--- a/include/ppu.h
+++ b/include/ppu.h
@@ -1,18 +1,275 @@
 #pragma once
+#include "cpu.h"
+#include "mappers/mapper-base.h"
 #include <cstdint>
 #include <array>
 
 using u8 = std::uint8_t;
 using u16 = std::uint16_t;
+using s16 = std::int16_t;
+
+using namespace std;
 
 class PPU
 {
   public:
-    PPU();
+    PPU( Bus *bus, bool isDisabled = false );
 
+    /*
+    ################################
+    ||           Getters          ||
+    ################################
+    */
+    [[nodiscard]] s16        GetScanline() const;
+    [[nodiscard]] u16        GetCycles() const;
+    [[nodiscard]] MirrorMode GetMirrorMode();
+
+    /*
+    ################################
+    ||           Setters          ||
+    ################################
+    */
+    void SetScanline( s16 scanline );
+    void SetCycles( u16 cycles );
+
+    /*
+    ################################
+    ||      CPU Read / Write      ||
+    ################################
+    */
     [[nodiscard]] u8 HandleCpuRead( u16 address );
     void             HandleCpuWrite( u16 address, u8 data );
 
+    /*
+    ################################
+    ||       Internal Reads       ||
+    ################################
+    */
+    [[nodiscard]] u8 Read( u16 addr );
+    [[nodiscard]] u8 ReadPatternTable( u16 addr );
+    [[nodiscard]] u8 ReadNameTable( u16 addr );
+
+    /*
+    ################################
+    ||       Internal Writes      ||
+    ################################
+    */
+    void Write( u16 addr, u8 data );
+    void WritePatternTable( u16 addr, u8 data );
+    void WriteNameTable( u16 addr, u8 data );
+
+    /*
+    ################################
+    ||         PPU Methods        ||
+    ################################
+    */
+    void DmaTransfer( u8 data );
+    u16  ResolveNameTableAddress( u16 addr );
+    void Tick();
+
   private:
-    std::array<u8, 8> _ppuRegisters{};
+    /*
+    ################################
+    ||      Global Variables      ||
+    ################################
+    */
+    s16  _scanline = 0;
+    u16  _cycle = 4;
+    u64  _frame = 1;
+    bool _isRenderingEnabled = false;
+
+    /*
+    ################################
+    ||       Debug Variables      ||
+    ################################
+    */
+    bool _isDisabled = false;
+
+    /*
+    ################################
+    ||         Peripherals        ||
+    ################################
+    */
+    Bus *_bus;
+
+    /*
+    ################################
+    ||    CPU-facing Registers    ||
+    ################################
+    */
+
+    union PPUCTRL
+    {
+        struct
+        {
+            u8 nametable_x : 1;
+            u8 nametable_y : 1;
+            u8 vram_increment : 1;
+            u8 pattern_sprite : 1;
+            u8 pattern_background : 1;
+            u8 sprite_size : 1;
+            u8 slave_mode : 1; // unused
+            u8 nmi_enable : 1;
+        } bit;
+        u8 value = 0x00;
+    };
+    union PPUMASK
+    {
+        struct
+        {
+            u8 grayscale : 1;
+            u8 render_background_left : 1;
+            u8 render_sprites_left : 1;
+            u8 render_background : 1;
+            u8 render_sprites : 1;
+            u8 enhance_red : 1;
+            u8 enhance_green : 1;
+            u8 enhance_blue : 1;
+        } bit;
+        u8 value = 0x00;
+    };
+    union PPUSTATUS
+    {
+        struct
+        {
+            u8 unused : 5;
+            u8 sprite_overflow : 1;
+            u8 sprite_zero_hit : 1;
+            u8 vertical_blank : 1;
+        } bit;
+        u8 value = 0x00;
+    };
+
+    PPUCTRL   _ppuCtrl;          // $2000
+    PPUMASK   _ppuMask;          // $2001
+    PPUSTATUS _ppuStatus;        // $2002
+    u8        _oamAddr = 0x00;   // $2003
+    u8        _oamData = 0x00;   // $2004
+    u8        _ppuScroll = 0x00; // $2005
+    u8        _ppuAddr = 0x00;   // $2006
+    u8        _ppuData = 0x00;   // $2007
+    // $4014: OAM DMA, handled in bus read/write, see bus.cpp
+
+    /*
+    ################################################################
+    ||                     Internal Registers                     ||
+    ################################################################
+    */
+    union LoopyRegister
+    {
+        struct
+        {
+            u16 coarse_x : 5;
+            u16 coarse_y : 5;
+            u16 nametable_x : 1;
+            u16 nametable_y : 1;
+            u16 fine_y : 3;
+            u16 unused : 1;
+        } bit;
+        u16 value = 0x00;
+    };
+    /* v: Current VRAM address (15 bits)
+       t: Temporary VRAM address (15 bits)
+
+      The v (and t) register has multiple purposes
+      - It allows the CPU to write to the PPU memory through _ppuAddr and _ppuData registers
+      - It points to the nametable data currently being drawn
+
+        yyy NN YYYYY XXXXX
+        ||| || ||||| +++++-- coarse X scroll
+        ||| || +++++-------- coarse Y scroll
+        ||| ++-------------- nametable select
+        +++----------------- fine Y scroll
+
+        There's also a temporary VRAM address, t, which is identical to v and is used to store
+        data temporarily until it is copied to v.
+
+        Both of these registers are sometimes referred to as "Loopy Registers", named
+        after the developer who discovered how they work.
+     */
+    LoopyRegister _vramAddr;
+    LoopyRegister _tempAddr;
+
+    // Internal fine X scroll register
+    u8 _fineX = 0x00;
+
+    // Used by _ppuScroll and _ppuAddr for two-write operations
+    bool _addrLatch = false;
+
+    // Stores last data written to _ppuData
+    u8 _ppuDataBuffer = 0x00;
+
+    /*
+    ################################################################
+    ||                  Internal Memory Locations                 ||
+    ################################################################
+    */
+    array<u8, 2048> _nameTables{};
+
+    /* Pattern Tables
+        $0000-$0FFF: Pattern Table 1
+        $1000-$1FFF: Pattern Table 2
+        Defined and documented in cartridge.h
+    */
+
+    /*
+       Palette Memory
+      $3F00-$3F0F: Background Palettes
+      $3F10-$3F1F: Sprite Palettes
+
+      A palette is a group of 4 indices, each index ranging from 0-63
+      The NES has 64 fixed colors, so each index represents a color
+
+      The colors won't be defined here, but somewhere in the SDL
+      rendering logic. We'll use .pal files to easily define and swap fixed colors
+      It's worth documenting what the palettes are, as this concept can be confusing
+
+      Background Palettes
+      Palette 0: $3F00 (bg color), $3F01, $3F02, $3F03.
+      Palette 1: $3F04 (bg color), $3F05, $3F06, $3F07.
+      Palette 2: $3F08 (bg color), $3F09, $3F0A, $3F0B.
+      Palette 3: $3F0C (bg color), $3F0D, $3F0E, $3F0F.
+
+      Sprite Palettes
+      Palette 4: $3F10 (mirrors 3F00), $3F11, $3F12, $3F13.
+      Palette 5: $3F14 (mirrors 3F04), $3F15, $3F16, $3F17.
+      Palette 6: $3F18 (mirrors 3F08), $3F19, $3F1A, $3F1B.
+      Palette 7: $3F1C (mirrors 3F0C), $3F1D, $3F1E, $3F1F.
+
+      Sprite backgrounds, despite being mirrored, are ignored and treated
+      as transparent.
+    */
+    // Default boot palette, will get changed by the cartridge
+    array<u8, 0x20> _paletteMemory = {
+        0x09, 0x01, 0x00, 0x01, // Palette 0
+        0x00, 0x02, 0x02, 0x0D, // Palette 1
+        0x08, 0x10, 0x08, 0x24, // Palette 2
+        0x00, 0x00, 0x04, 0x2C, // Palette 3
+        0x09, 0x01, 0x34, 0x03, // Palette 4
+        0x00, 0x04, 0x00, 0x14, // Palette 5
+        0x08, 0x3A, 0x00, 0x02, // Palette 6
+        0x00, 0x20, 0x2C, 0x08  // Palette 7
+    };
+
+    /* Object Attribute Memory (OAM)
+       This is a 256 byte region internal to the PPU
+       It holds metadata for up to 64 sprites, with each sprite taking up 4 bytes.
+
+      Byte 0: Y position of the sprite
+      Byte 1: Tile index number
+        76543210
+        ||||||||
+        |||||||+- Bank ($0000 or $1000) of tiles
+        +++++++-- Tile number of top of sprite (0 to 254; bottom half gets the next tile)
+      Byte 2: Attributes
+        76543210
+        ||||||||
+        ||||||++- Palette (4 to 7) of sprite
+        |||+++--- Unimplemented (read 0)
+        ||+------ Priority (0: in front of background; 1: behind background)
+        |+------- Flip sprite horizontally
+        +-------- Flip sprite vertically
+      Byte 3: X position of the sprite
+    */
+    array<u8, 256> _oam{};
 };

--- a/src/bus.cpp
+++ b/src/bus.cpp
@@ -6,13 +6,13 @@
 #include <utility>
 
 // Constructor to initialize the bus with a flat memory model
-Bus::Bus( PPU *ppu, const bool use_flat_memory ) : _ppu( ppu ), _use_flat_memory( use_flat_memory )
+Bus::Bus( const bool use_flat_memory ) : cpu( this ), ppu( this ), _use_flat_memory( use_flat_memory )
 {
     _ram.fill( 0 );
     _apu_io_memory.fill( 0 );
 }
 
-u8 Bus::Read( const u16 address ) const
+u8 Bus::Read( const u16 address )
 {
     if ( _use_flat_memory )
     {
@@ -30,7 +30,7 @@ u8 Bus::Read( const u16 address ) const
     {
         // ppu read will go here. For now, return from temp private member of bus
         const u16 ppu_register = 0x2000 + ( address & 0x0007 );
-        return _ppu->HandleCpuRead( ppu_register );
+        return ppu.HandleCpuRead( ppu_register );
     }
 
     // APU and I/O Registers: 0x4000 - 0x401F
@@ -44,7 +44,7 @@ u8 Bus::Read( const u16 address ) const
     // 4020 and up is cartridge territory
     if ( address >= 0x4020 && address <= 0xFFFF )
     {
-        return _cartridge->Read( address );
+        return cartridge->Read( address );
     }
 
     // Unhandled address ranges return open bus value
@@ -71,7 +71,7 @@ void Bus::Write( const u16 address, const u8 data )
     if ( address >= 0x2000 && address <= 0x3FFF )
     {
         const u16 ppu_register = 0x2000 + ( address & 0x0007 );
-        _ppu->HandleCpuWrite( ppu_register, data );
+        ppu.HandleCpuWrite( ppu_register, data );
         return;
     }
 
@@ -82,10 +82,17 @@ void Bus::Write( const u16 address, const u8 data )
         return;
     }
 
+    // PPU DMA: 0x4014
+    if ( address == 0x4014 )
+    {
+        ppu.DmaTransfer( data );
+        return;
+    }
+
     // 4020 and up is cartridge territory
     if ( address >= 0x4020 && address <= 0xFFFF )
     {
-        _cartridge->Write( address, data );
+        cartridge->Write( address, data );
         return;
     }
     // Unhandled address ranges
@@ -93,4 +100,7 @@ void Bus::Write( const u16 address, const u8 data )
     std::cout << "Unhandled write to address: " << std::hex << address << "\n";
 }
 
-void Bus::LoadCartridge( std::shared_ptr<Cartridge> cartridge ) { _cartridge = std::move( cartridge ); }
+void Bus::LoadCartridge( std::shared_ptr<Cartridge> loaded_cartridge )
+{
+    cartridge = std::move( loaded_cartridge );
+}

--- a/src/cartridge.cpp
+++ b/src/cartridge.cpp
@@ -69,11 +69,17 @@ Cartridge::Cartridge( const std::string &file_path )
 
     // Mirror mode
     // Provided by the 0th bit of byte 6.
-    _mirror_mode = header[6] & 0b00000001;
+    u8 mirror_mode = header[6] & 0b00000001;
+    ( mirror_mode == 0 ) ? _mirror_mode = MirrorMode::Horizontal : _mirror_mode = MirrorMode::Vertical;
 
     // Four screen mode
     // Provided by the 3rd bit of byte 6.
-    _four_screen_mode = ( flags6 & 0b00001000 );
+    // If provided, it overrides info in byte 0
+    _four_screen_mode = ( flags6 & 0b00001000 ) != 0;
+    if ( _four_screen_mode )
+    {
+        _mirror_mode = MirrorMode::FourScreen;
+    }
 
     // PRG and CHR banks, derived from bytes 4 and 5
     u8 const     prg_rom_banks = header[4];
@@ -166,6 +172,10 @@ Cartridge::Cartridge( const std::string &file_path )
     {
         return ReadChrROM( address );
     }
+    if ( address >= 2800 && address <= 0x2FFF )
+    {
+        return ReadCartridgeVRAM( address );
+    }
 
     // From the CPU
     if ( address >= 0x4020 && address <= 0x5FFF )
@@ -192,6 +202,11 @@ void Cartridge::Write( u16 address, u8 data )
     if ( address >= 0x0000 && address <= 0x1FFF )
     {
         WriteChrRAM( address, data );
+        return;
+    }
+    if ( address >= 2800 && address <= 0x2FFF )
+    {
+        WriteCartridgeVRAM( address, data );
         return;
     }
 
@@ -274,6 +289,18 @@ void Cartridge::Write( u16 address, u8 data )
     return 0xFF;
 }
 
+[[nodiscard]] u8 Cartridge::ReadCartridgeVRAM( u16 address )
+{
+    /** @brief Reads from the cartridge VRAM, ranges from 0x2800 to 0x2FFF
+     * This is used by the PPU in four-screen mode
+     */
+    if ( address >= 0x2800 && address <= 0x2FFF )
+    {
+        return _cartridge_vram[address & 0x07FF]; // Mask to 2Kib
+    }
+    return 0xFF;
+}
+
 /*
 ################################
 ||                            ||
@@ -347,6 +374,17 @@ void Cartridge::WriteExpansionRAM( u16 address, u8 data )
     }
 }
 
+void Cartridge::WriteCartridgeVRAM( u16 address, u8 data )
+{
+    /** @brief Writes to the cartridge VRAM, ranges from 0x2800 to 0x2FFF
+     * This is used by the PPU in four-screen mode
+     */
+    if ( address >= 0x2800 && address <= 0x2FFF )
+    {
+        _cartridge_vram[address & 0x07FF] = data;
+    }
+}
+
 /*
 ################################
 ||                            ||
@@ -354,11 +392,32 @@ void Cartridge::WriteExpansionRAM( u16 address, u8 data )
 ||                            ||
 ################################
 */
+
 MirrorMode Cartridge::GetMirrorMode()
 {
     /** @brief Returns the mirror mode of the cartridge
-     * The mirror mode determines how the PPU should handle nametable mirroring
-     * We'll let each mapper determine the mirror mode
+     * The mirror mode determines how the PPU should handle nametable mirroring.
+     *
+     * Mapper 0:
+     *   - Mirroring mode is statically defined in the iNES header (bit 0 of byte 6).
+     *   - It cannot change dynamically and is "soldered" for each specific game.
+     *
+     * Four-Screen Mode:
+     *   - Indicated by bit 3 of byte 6 in the iNES header.
+     *   - Overrides any mirroring mode (horizontal or vertical) defined in bit 0.
+     *   - This mode provides unique nametables for all four screens using extra cartridge VRAM.
+     *
+     * Other mappers:
+     *   - Mirroring mode is controlled dynamically via mapper logic.
+     *   - The specific mirroring configuration depends on the mapper implementation.
      */
+
+    // Mapper 0 or Four-Screen Mode: Static mirroring, determined by iNES header
+    if ( _mapper_number == 0 || _four_screen_mode )
+    {
+        return _mirror_mode;
+    }
+
+    // Other mappers: Dynamic mirroring, determined by mapper logic
     return _mapper->GetMirrorMode();
 }

--- a/src/cartridge.cpp
+++ b/src/cartridge.cpp
@@ -69,7 +69,7 @@ Cartridge::Cartridge( const std::string &file_path )
 
     // Mirror mode
     // Provided by the 0th bit of byte 6.
-    u8 mirror_mode = header[6] & 0b00000001;
+    u8 const mirror_mode = header[6] & 0b00000001;
     ( mirror_mode == 0 ) ? _mirror_mode = MirrorMode::Horizontal : _mirror_mode = MirrorMode::Vertical;
 
     // Four screen mode

--- a/src/ppu.cpp
+++ b/src/ppu.cpp
@@ -1,6 +1,7 @@
 #include "ppu.h"
 #include "bus.h"
-#include "cartridge.h"
+#include "cartridge.h" // NOLINT(misc-include-cleaner)
+#include "mappers/mapper-base.h"
 
 PPU::PPU( Bus *bus, bool isDisabled ) : _isDisabled( isDisabled ), _bus( bus ) {}
 
@@ -443,7 +444,7 @@ void PPU::Tick() // NOLINT
     // Cycles 321-336 are beyond the visible scanline, but continue for the next scanline
     if ( ( _cycle >= 1 && _cycle <= 256 ) || ( _cycle >= 321 && _cycle <= 336 ) )
     {
-        u8 stage = ( _cycle - 1 ) & 0x07;
+        u8 const stage = ( _cycle - 1 ) & 0x07;
 
         switch ( stage )
         {
@@ -572,7 +573,7 @@ void PPU::Tick() // NOLINT
 
 u16 PPU::ResolveNameTableAddress( u16 addr )
 {
-    MirrorMode mirror_mode = _bus->cartridge->GetMirrorMode();
+    MirrorMode const mirror_mode = _bus->cartridge->GetMirrorMode();
 
     switch ( mirror_mode )
     {

--- a/src/ppu.cpp
+++ b/src/ppu.cpp
@@ -1,7 +1,624 @@
 #include "ppu.h"
+#include "bus.h"
+#include "cartridge.h"
 
-PPU::PPU() = default;
+PPU::PPU( Bus *bus, bool isDisabled ) : _isDisabled( isDisabled ), _bus( bus ) {}
 
-[[nodiscard]] u8 PPU::HandleCpuRead( u16 address ) { return _ppuRegisters[address]; }
+/*
+################################
+||                            ||
+||           Getters          ||
+||                            ||
+################################
+*/
+[[nodiscard]] s16 PPU::GetScanline() const { return _scanline; }
+[[nodiscard]] u16 PPU::GetCycles() const { return _cycle; }
 
-void PPU::HandleCpuWrite( u16 address, u8 data ) { _ppuRegisters[address] = data; }
+/*
+################################
+||                            ||
+||           Setters          ||
+||                            ||
+################################
+*/
+void PPU::SetScanline( s16 scanline ) { _scanline = scanline; }
+void PPU::SetCycles( u16 cycles ) { _cycle = cycles; }
+
+/*
+################################
+||                            ||
+||       Handle CPU Read      ||
+||                            ||
+################################
+*/
+[[nodiscard]] u8 PPU::HandleCpuRead( u16 address ) // NOLINT
+{
+
+    /* @brief: CPU reads to the PPU
+     * @details: Unlike other places in memory. Reads can cause PPU status updates.
+     */
+
+    // Non-readable registers: 2000 (PPUCTRL), 2001 (PPUMASK), 2003 (OAMADDR), 2005 (PPUSCROLL),
+    // 2006 (PPUADDR)
+    if ( _isDisabled || address == 0x2000 || address == 0x2001 || address == 0x2003 || address == 0x2005 ||
+         address == 0x2006 )
+    {
+        return 0xFF;
+    }
+
+    // 2002: PPU Status Register
+    if ( address == 0x2002 )
+    {
+        /*
+         * Side Effects of Reading:
+         *   1. Clears the vertical blank flag (Bit 7).
+         *   2. Resets the PPU address latch for $2005/$2006.
+
+         * The CPU expects the state of the PPU at the time of the read. The vertical
+         * blank flag is cleared after constructing the return value, ensuring the
+         * CPU sees the state before the read's side effects.
+         */
+        // TODO: Implement
+        return 0xFF;
+    }
+    // 2004: OAM Data
+    if ( address == 0x2004 )
+    {
+        /*
+           Return the contents of _oam[_oamaddr]
+           If called while _renderingEnabled and in visible scanline range (0-239),
+           Returns corrupted data (0xFF)
+        */
+        // TODO: Impelement
+    }
+
+    // 2007: PPU Data
+    if ( address == 0x2007 )
+    {
+        /*
+          Reads the data at the current _vramAddr
+          When reading from palette memory, (0x3F00-0x3FFF), direct data is returned
+          Otherwise, the data from the current _ppuDataBuffer is returned, simulating
+          a delayed read by 1 cycle, and the _vramAddr is then incremented by 1 or 32.
+          1 if _ppuCtrl increment mode is 0, 32 if 1.
+          The _ppuDataBuffer is then updated with the data at the new _vramAddr, in preparation
+          for the next non-palette memory read.
+         */
+        // TODO: Implement
+    }
+    return 0xFF;
+}
+
+/*
+################################
+||                            ||
+||      Handle CPU Write      ||
+||                            ||
+################################
+*/
+
+void PPU::HandleCpuWrite( u16 address, u8 data ) // NOLINT
+{
+    /* @brief: CPU writes to the PPU
+     */
+    if ( _isDisabled )
+    {
+        return;
+    }
+
+    (void) data; // NOTE: Remove after using data
+
+    switch ( address )
+    {
+        // 2000: PPUCTRL
+        case 0x2000: // NOLINT
+        {
+            /*
+              This write sets _ppuCtrl to data.
+              If _ppuCtrl nmi is enabled and if _ppuStatus vertical blank is set,
+              initiates an non-maskable interrupt.
+              Additionally, _tempAddr nametable x and y bits are update from the
+              _cpuCtrl nametable x and y bits.
+             */
+            // TODO: Implement
+            break;
+        }
+        // 2001: PPUMASK
+        case 0x2001:
+        {
+            /*
+              Sets _ppuMask to data
+              _isRenderingEnabled can be determined here based on whether
+              bg_enabled and sprite_enabled bits are set in the _ppuMask
+            */
+            // TODO: Implement
+            break;
+        }
+        // 2002: PPUSTATUS, does nothing
+        case 0x2002:
+            break;
+        // 2003: OAMADDR
+        case 0x2003: // NOLINT
+        {
+            /*
+              Sets _oamAddr to data
+             */
+            // TODO: Implement
+            break;
+        }
+        // 2004: OAMDATA
+        case 0x2004:
+        {
+            /*
+              Writes data to _oam[_oamAddr]
+              Increments _oamAddr
+              If _isRenderingEnabled and in visible scanline range (0-239),
+              Ignore the write
+             */
+            // TODO: Implement
+            break;
+        }
+        // 2005: PPUSCROLL
+        case 0x2005: // NOLINT
+        {
+            /*
+               Updates the coarse x, y and fine x, y in two writes
+               Coarse x, coarse y, and fine y are encoded into _tempAddr
+               Fine x has its own register, _fineX
+            */
+            if ( !_addrLatch ) // NOLINT
+            {
+                /* First Write
+                  Sets _tempAddr coarse x from bits 3-7 of data (data & 0b11111000)
+                  Sets _fineX from bits 0-2 of data (data & 0b00000111)
+                  Toggles _addrLatch
+                 */
+                // TODO: Implement
+            }
+            else
+            {
+                /* Second Write
+                  Sets _tempAddr fine y from bits 0-2 of data (data & 0b00000111)
+                  Sets _tempAddr coarse y from bits 3-7 of data (data & 0b11111000)
+                  Toggles _addrLatch
+                 */
+                // TODO: Implement
+            }
+            break;
+        }
+        // 2006: PPUADDR
+        case 0x2006:
+        {
+            /*
+              Updates the high and low byte of the _tempAddr in two writes
+              High byte is written first
+              Low byte is written second
+             */
+            if ( !_addrLatch ) // NOLINT
+            {
+                /* First Write
+                   _tempAddr high byte is derived from the first bits of data (data & 0b00111111)
+                   and is set to bits 8-14 of _tempAddr
+                   The _addrLatch is toggled
+                 */
+                // TODO: Implement
+            }
+            else
+            {
+                /* Second Write
+                   The entire data byte is the _tempAddr low byte
+                   _tempAddr low byte is updated with the data byte
+                  _tempAddr is copied to _vramAddr
+                  _addrLatch is toggled
+                 */
+                // TODO: Implement
+            }
+            break;
+        }
+        // 2007: PPU Data
+        case 0x2007:
+        {
+            /*
+               data is written to the current _vramAddr
+              _vramAddr is then incremented by 1 or 32.
+              1 if _ppuCtrl increment mode is 0, 32 if 1
+            */
+            // TODO: Implement
+        }
+        default:
+            break;
+    }
+}
+
+/*
+################################
+||                            ||
+||           OAM DMA          ||
+||                            ||
+################################
+*/
+
+void PPU::DmaTransfer( u8 data ) // NOLINT
+{
+    /* @details CPU writes to address $4014 to initiate a DMA transfer
+     * DMA transfer is a way to quickly transfer data from CPU memory to the OAM.
+     * The CPU sends the starting address, N, to $4014, which is the high byte of the
+     * source address
+     * i.e. 0x02 -> 0x0200, 0x03 -> 0x0300, etc.
+     *
+     * Once the DMA transfer starts, the CPU reads 256 bytes sequentally from the address
+     * into the OAM. The CPU is halted for 513/514 cycles during this time. Games usually
+     * trigger this during a Vblank period
+     *
+     * Practically speaking, updating the OAM means updating the sprite information on screen
+     *
+     * This is not the only way to update the OAM, registers 2004 and 2003 can be used
+     * but those are slower, and are used for partial updates mostly
+     */
+    // TODO: Implement
+    (void) data;
+}
+
+/*
+################################
+||                            ||
+||          PPU Read          ||
+||                            ||
+################################
+*/
+
+[[nodiscard]] u8 PPU::Read( u16 address ) // NOLINT
+{
+    /*@brief: Internal PPU reads to the cartridge
+     */
+
+    // $0000-$1FFF: Pattern Tables
+    if ( address >= 0x0000 && address <= 0x1FFF )
+    {
+        /* Pattern table data is read from the cartridge */
+        // TODO: Implement
+    }
+
+    // $2000-$3EFF: Name Tables
+    if ( address >= 0x2000 && address <= 0x3EFF )
+    {
+        /*
+           Name table data is read from _nameTables
+          _nameTables is a 2KiB array, with each name table taking up 1KiB
+          Appropriate mirroing logic is handled in ResolveNameTableAddress
+
+          If the mirroring mode is four screen, that means 4 name tables are
+          used, each 1KiB in size. Since _nameTables is only 2KiB, any address
+          above 0x2800 must be directed to the cartridge, which provides the
+          additional name table space. It's not necessary to emulate it this
+          way, but it's a more accurate paradigm because that's how the hardware
+          handles it.
+
+          // TODO: Implement
+        */
+    }
+
+    // $3F00-$3FFF: Palettes
+    if ( address >= 0x3F00 && address <= 0x3FFF )
+    {
+        /*
+        Background Palettes
+        Palette 0: $3F00 (bg color), $3F01, $3F02, $3F03.
+        Palette 1: $3F04 (bg color), $3F05, $3F06, $3F07.
+        Palette 2: $3F08 (bg color), $3F09, $3F0A, $3F0B.
+        Palette 3: $3F0C (bg color), $3F0D, $3F0E, $3F0F.
+
+        Sprite Palettes
+        Palette 4: $3F10 (mirrors 3F00), $3F11, $3F12, $3F13.
+        Palette 5: $3F14 (mirrors 3F04), $3F15, $3F16, $3F17.
+        Palette 6: $3F18 (mirrors 3F08), $3F19, $3F1A, $3F1B.
+        Palette 7: $3F1C (mirrors 3F0C), $3F1D, $3F1E, $3F1F.
+
+        The address is masked to 32 bytes.
+        Addresses 3F10, 3F14, 3F18 and 3F1C mirror 3F00, 3F04, 3F08 and 3F0C respectively
+        */
+        // TODO: Implement
+    }
+
+    return 0xFF;
+}
+
+/*
+################################
+||                            ||
+||          PPU Write         ||
+||                            ||
+################################
+*/
+void PPU::Write( u16 address, u8 data ) // NOLINT
+{
+    /*@brief: Internal PPU reads to the cartridge
+     */
+
+    (void) data;
+    address &= 0x3FFF;
+
+    if ( address >= 0x0000 && address <= 0x1FFF )
+    {
+        /* Pattern table data is written to the cartridge */
+        // TODO: Implement
+    }
+    if ( address >= 0x2000 && address <= 0x2FFF )
+    {
+
+        /*
+           Name table data is written to _nameTables
+          _nameTables is a 2KiB array, with each name table taking up 1KiB
+          Appropriate mirroing logic is handled in ResolveNameTableAddress
+
+          If the mirroring mode is four screen, that means 4 name tables are
+          used, each 1KiB in size. Since _nameTables is only 2KiB, any address
+          above 0x2800 must be directed to the cartridge, which provides the
+          additional name table space.
+        */
+        // TODO: Implement
+    }
+
+    // $3F00-$3FFF: Palettes
+    if ( address >= 0x3F00 && address <= 0x3FFF )
+    {
+
+        /* The address is masked to 32 bytes.
+        Addresses 3F10, 3F14, 3F18 and 3F1C mirror 3F00, 3F04, 3F08 and 3F0C respectively
+        */
+        // TODO: Implement
+    }
+}
+
+/*
+################################
+||                            ||
+||       PPU Cycle Tick       ||
+||                            ||
+################################
+*/
+void PPU::Tick() // NOLINT
+{
+    if ( _isDisabled )
+    {
+        return;
+    }
+
+    /*
+    ################################
+    ||    Odd Frame Cycle Skip    ||
+    ################################
+    */
+    // TODO: Implement
+
+    /*
+    ################################
+    ||       Increment Cycle      ||
+    ################################
+    */
+    _cycle++;
+
+    /*
+    ################################
+    ||       End Of Scanline      ||
+    ################################
+    */
+    // TODO: Implement
+
+    /*
+    ################################
+    ||        Vblank Start        ||
+    ################################
+    */
+    // TODO: Implement
+
+    /*
+    ################################
+    ||         Vblank End         ||
+    ################################
+    */
+    // TODO: Implement
+
+    /*
+    ################################
+    ||    Transfer Y (280-340)    ||
+    ################################
+    */
+    // TODO: Implement
+
+    /*
+    ################################
+    ||  Visible Scalines (0-239)  ||
+    ################################
+    */
+
+    if ( _scanline < 0 || _scanline > 239 )
+    {
+        return;
+    }
+
+    // Cycle 0, Idle cycle
+
+    // Cycles 1-256: Tile and Pixel Rendering
+    // Cycles 321-336 are beyond the visible scanline, but continue for the next scanline
+    if ( ( _cycle >= 1 && _cycle <= 256 ) || ( _cycle >= 321 && _cycle <= 336 ) )
+    {
+        u8 stage = ( _cycle - 1 ) & 0x07;
+
+        switch ( stage )
+        {
+            // 0-1 fetch the nametable byte
+            case 1:
+                // Grab the first 12 bits of the vram address
+                // which provide nametable select, coarse Y scroll, and coarse x scroll information
+                // Nametable address is 0x2000 plus the offset of the vram address.
+                // TODO: Implement
+                break;
+
+            // 2-3 fetch the attribute table byte
+            case 3: // NOLINT
+            {
+                /* Attribute Table
+                The attribute table is a 64-byte region located at addresses 0x23C0-0x23FF within the
+                nametable memory. Each byte corresponds to a 32x32 pixel region on the screen,
+                which is further divided into 4 smaller 16x16 pixel boxes.
+
+                Each attribute byte determines the palette ID for each of these 16x16 pixel boxes,
+                allowing the PPU to assign distinct color palettes to specific screen regions.
+
+                Attribute Byte Structure:
+                7654 3210
+                |||| ||++- Palette ID for the top-left 16x16 pixel box
+                |||| ++--- Palette ID for the top-right 16x16 pixel box
+                ||++------ Palette ID for the bottom-left 16x16 pixel box
+                ++-------- Palette ID for the bottom-right 16x16 pixel box
+
+                Example:
+                Attribute Byte: 1010 0111
+                  |||| ||++- 11 (palette 3) for top-left box
+                  |||| ++--- 01 (palette 1) for top-right box
+                  ||++------ 10 (palette 2) for bottom-left box
+                  ++-------- 10 (palette 2) for bottom-right box
+
+                Visual Representation:
+                  ,---- Top-left (palette 3)
+                  |3 1 - Top-right (palette 1)
+                  |2 2 - Bottom-right (palette 2)
+                  `---- Bottom-left (palette 2)
+
+                Each attribute byte affects a 32x32 pixel region. The attribute table covers the
+                entire screen as an 8x8 grid of 32x32 regions (totaling 256x240 pixels).
+                The first 8 bytes of the attribute table correspond to the top row of 32x256 pixels,
+                the next 8 bytes correspond to the next row, and so on.
+
+                Attribute Table Coverage:
+                - Top-left corner of the screen: Address 0x23C0
+                - Bottom-right corner of the screen: Address 0x23FF
+                */
+
+                // The attribute is 12 bits and is composed as follows
+                /*
+                NN 1111 YYY XXX
+                || |||| ||| +++-- high 3 bits of coarse X (x/4)
+                || |||| +++------ high 3 bits of coarse Y (y/4)
+                || ++++---------- attribute offset (from the 23C0 offset)
+                ++--------------- nametable select
+                */
+                // TODO: Implement
+                break;
+            }
+            // 4-5 fetch pattern table plane 0
+            case 5:
+            {
+                /*
+                  If the name tables provide the "which tile" and "which palette",
+                  the pattern table byte provides the "which pixel" and the "which palette color"
+
+                  A pattern table byte represents an 8x8 tile.
+                  Each bit is a 2bit color value (0-3). How can two bits fit into one bit?
+                  They can't. That's why two planes are used.
+                  Plane 0 holds the least significant bit of the color value
+                  Plane 1 holds the most significant bit of the color value
+                  A pattern table byte is grabbed in two reads, and the values are then combined
+
+                  Here's an illustration with just 4 bits
+                  Plane 1:   1010
+                  Plane 0:   1100,
+
+                  Index:     3120
+
+                  Reading vertically, 0b11 = 3, 0b01 = 1, 0b10 = 2, 0b00 = 0
+                  The 3, 1, 2, and 0 are the palette indeces for these pixels
+                 */
+
+                // TODO: Implement
+                break;
+            }
+            // 6-7 fetch pattern table plane 1
+            // 7: Increment scroll x
+            // 7: Increment scroll y on cycle 256
+            case 7:
+            {
+                // TODO: Implement
+                break;
+            }
+            default:
+                break;
+        }
+    }
+
+    /*
+    #################################
+    ||  Transfer X Position (257)  ||
+    #################################
+    */
+    // TODO: Implement
+
+    /*
+    ################################
+    ||   Unused Reads (338, 340)  ||
+    ################################
+    */
+    // TODO: Implement
+}
+
+/*
+################################
+||                            ||
+||           Helpers          ||
+||                            ||
+################################
+*/
+
+u16 PPU::ResolveNameTableAddress( u16 addr )
+{
+    MirrorMode mirror_mode = _bus->cartridge->GetMirrorMode();
+
+    switch ( mirror_mode )
+    {
+        case MirrorMode::SingleUpper: // NOLINT
+            // All addresses fall within 2000-23FF, nametable 0
+            // TODO: Implement
+            break;
+        case MirrorMode::SingleLower:
+            // All addresses fall within 2800-2BFF, nametable 2
+            // TODO: Implement
+            break;
+        case MirrorMode::Vertical:
+            /* Vertical Mirroring
+              The two horizontal sections are unique, but the two vertical sections are mirrored
+              2800-2FFF is a mirror of 2000-27FF
+
+              2000 2400
+              ^    ^
+              v    v
+              2800 2C00
+
+              Horizontal scrolling games will use this mode. When screen data exceeds 27FF, it's
+              wrapped back to 2000.
+             */
+            return addr & 0x07FF;
+        case MirrorMode::Horizontal:
+            /* Horizontal Mirroring
+              The two vertical sections are unique, but the two horizontal sections are mirrored
+              2400-27FF is a mirror of 2000-23FF
+              2C00-2FFF is a mirror of 2800-2BFF
+
+              2000 < > 2400
+              2800 < > 2C00
+
+              Horizontal mode is used for vertical scrolling games, like Kid Icarus.
+             */
+            // TODO: Implement
+
+        case MirrorMode::FourScreen:
+            /* Four-Screen Mirroring
+               All four nametables are unique and backed by cartridge VRAM. There's no mirroring.
+             */
+            return addr & 0x0FFF;
+        default:
+            // Default to vertical mirroring
+            return addr & 0x07FF;
+    }
+    return 0xFF;
+}

--- a/tests/cpu_test.cpp
+++ b/tests/cpu_test.cpp
@@ -24,17 +24,16 @@ class CPUTestFixture : public ::testing::Test
 // This class is a test fixture that provides shared setup and teardown for all tests
 {
   protected:
-    CPU cpu; // NOLINT
-    Bus bus; // NOLINT
-    PPU ppu; // NOLINT
-
     // All tests assume flat memory model, which is why true is passed to Bus constructor
-    CPUTestFixture() : cpu( &bus ), bus( &ppu, true ) {}
+    Bus bus = Bus( true ); // NOLINT
+    CPU cpu;               // NOLINT
+    PPU ppu;               // NOLINT
+
+    CPUTestFixture() : ppu( bus.ppu ), cpu( bus.cpu ) {}
 
     void                      RunTestCase( const json &testCase );
     void                      LoadStateFromJson( const json &jsonData, const std::string &state );
-    [[nodiscard]] std::string GetCPUStateString( const json        &jsonData,
-                                                 const std::string &state ) const;
+    [[nodiscard]] std::string GetCPUStateString( const json &jsonData, const std::string &state ) const;
 
     // Expose private methods
     // CPUTestFixture is a friend class of CPU. To use cpu private methods, we need to create
@@ -91,8 +90,7 @@ TEST_F( CPUTestFixture, StatusFlags )
     SetFlags( interrupt_disable );
     EXPECT_EQ( cpu.GetStatusRegister(), 0x00 | carry | zero | interrupt_disable | unused );
     SetFlags( decimal );
-    EXPECT_EQ( cpu.GetStatusRegister(),
-               0x00 | carry | zero | interrupt_disable | decimal | unused );
+    EXPECT_EQ( cpu.GetStatusRegister(), 0x00 | carry | zero | interrupt_disable | decimal | unused );
     SetFlags( break_flag );
     EXPECT_EQ( cpu.GetStatusRegister(),
                0x00 | carry | zero | interrupt_disable | decimal | break_flag | unused );
@@ -103,13 +101,11 @@ TEST_F( CPUTestFixture, StatusFlags )
     SetFlags( negative );
     EXPECT_EQ( cpu.GetStatusRegister(), 0x00 | overflow | negative );
     // set all flags
-    SetFlags( carry | zero | interrupt_disable | decimal | break_flag | overflow | negative |
-              unused );
-    EXPECT_EQ( cpu.GetStatusRegister(), 0x00 | carry | zero | interrupt_disable | decimal |
-                                            break_flag | overflow | negative | unused );
+    SetFlags( carry | zero | interrupt_disable | decimal | break_flag | overflow | negative | unused );
+    EXPECT_EQ( cpu.GetStatusRegister(), 0x00 | carry | zero | interrupt_disable | decimal | break_flag |
+                                            overflow | negative | unused );
     // clear all flags
-    ClearFlags( carry | zero | interrupt_disable | decimal | break_flag | overflow | negative |
-                unused );
+    ClearFlags( carry | zero | interrupt_disable | decimal | break_flag | overflow | negative | unused );
     EXPECT_EQ( cpu.GetStatusRegister(), 0x00 );
 
     // IsFlagSet method
@@ -263,8 +259,7 @@ TEST_F( CPUTestFixture, IND )
 
     // Write a value at the effective address
     Write( addr, 0xEF );
-    EXPECT_EQ( Read( addr ), 0xEF )
-        << "Expected 0xEF, but got " << static_cast<int>( Read( addr ) );
+    EXPECT_EQ( Read( addr ), 0xEF ) << "Expected 0xEF, but got " << static_cast<int>( Read( addr ) );
 
     // Ensure the pc is incremented by 2
     EXPECT_EQ( cpu.GetProgramCounter(), 0x0002 );
@@ -295,8 +290,7 @@ TEST_F( CPUTestFixture, IND_Bug )
     Write( no_bug_addr, 0xAB );
 
     u16 const effective_addr = IND();
-    EXPECT_EQ( effective_addr, bug_addr )
-        << "Expected 0x1234, but got " << std::hex << effective_addr;
+    EXPECT_EQ( effective_addr, bug_addr ) << "Expected 0x1234, but got " << std::hex << effective_addr;
     EXPECT_EQ( Read( effective_addr ), 0xEF )
         << "Expected 0xEF, but got " << static_cast<int>( Read( effective_addr ) );
     EXPECT_EQ( cpu.GetProgramCounter(), 0x0002 );
@@ -324,8 +318,7 @@ TEST_F( CPUTestFixture, INDX )
     Write( effective_addr, 0x42 );
 
     u16 const addr = INDX();
-    EXPECT_EQ( addr, effective_addr )
-        << "Expected " << std::hex << effective_addr << ", but got " << addr;
+    EXPECT_EQ( addr, effective_addr ) << "Expected " << std::hex << effective_addr << ", but got " << addr;
     EXPECT_EQ( Read( addr ), 0x42 ) << "Expected 0x42, but got " << int( Read( addr ) ); // NOLINT
     EXPECT_EQ( cpu.GetProgramCounter(), 0x0001 );
 
@@ -372,8 +365,7 @@ TEST_F( CPUTestFixture, REL )
     cpu.SetProgramCounter( 0x1000 );
     Write( 0x1000, 0x05 );
     u16 const forward_branch = REL();
-    EXPECT_EQ( forward_branch, 0x1006 )
-        << "Expected 0x1006, but got " << std::hex << forward_branch;
+    EXPECT_EQ( forward_branch, 0x1006 ) << "Expected 0x1006, but got " << std::hex << forward_branch;
     EXPECT_EQ( cpu.GetProgramCounter(), 0x1001 ) << "Expected PC to be 0x1001 after REL";
 
     printTestStartMsg( test_name );
@@ -392,17 +384,17 @@ TEST_F( CPUTestFixture, REL )
  * e.g. x00_BRK_Implied, x01_ORA_IndirectX, x05_ORA_ZeroPage, etc.
  */
 // NOLINTBEGIN(cppcoreguidelines-macro-usage)
-#define CPU_TEST( opcode_hex, mnemonic, addr_mode, filename )                                      \
-    TEST_F( CPUTestFixture, x##opcode_hex##_##mnemonic##_##addr_mode )                             \
-    {                                                                                              \
-        std::string const testName = #opcode_hex " " #mnemonic " " #addr_mode;                     \
-        printTestStartMsg( testName );                                                             \
-        json const testCases = extractTestsFromJson( "tests/json/" filename );                     \
-        for ( const auto &testCase : testCases )                                                   \
-        {                                                                                          \
-            RunTestCase( testCase );                                                               \
-        }                                                                                          \
-        printTestEndMsg( testName );                                                               \
+#define CPU_TEST( opcode_hex, mnemonic, addr_mode, filename )                                                \
+    TEST_F( CPUTestFixture, x##opcode_hex##_##mnemonic##_##addr_mode )                                       \
+    {                                                                                                        \
+        std::string const testName = #opcode_hex " " #mnemonic " " #addr_mode;                               \
+        printTestStartMsg( testName );                                                                       \
+        json const testCases = extractTestsFromJson( "tests/json/" filename );                               \
+        for ( const auto &testCase : testCases )                                                             \
+        {                                                                                                    \
+            RunTestCase( testCase );                                                                         \
+        }                                                                                                    \
+        printTestEndMsg( testName );                                                                         \
     }
 // NOLINTEND(cppcoreguidelines-macro-usage)
 
@@ -845,8 +837,7 @@ void CPUTestFixture::LoadStateFromJson( const json &jsonData, const std::string 
     }
 }
 
-std::string CPUTestFixture::GetCPUStateString( const json        &jsonData,
-                                               const std::string &state ) const
+std::string CPUTestFixture::GetCPUStateString( const json &jsonData, const std::string &state ) const
 {
     /*
     This function provides formatted output for expected vs. actual CPU state values,
@@ -887,14 +878,13 @@ std::string CPUTestFixture::GetCPUStateString( const json        &jsonData,
            << std::setw( value_width ) << "ACTUAL" << '\n';
 
     // Function to format and print a line
-    auto print_line =
-        [&]( const std::string &label, const uint64_t expected, const uint64_t actual )
+    auto print_line = [&]( const std::string &label, const uint64_t expected, const uint64_t actual )
     {
         auto to_hex_decimal_string = []( const uint64_t value, const int width )
         {
             std::stringstream str_stream;
-            str_stream << std::hex << std::uppercase << std::setw( width ) << std::setfill( '0' )
-                       << value << " (" << std::dec << value << ")";
+            str_stream << std::hex << std::uppercase << std::setw( width ) << std::setfill( '0' ) << value
+                       << " (" << std::dec << value << ")";
             return str_stream.str();
         };
 
@@ -947,8 +937,7 @@ std::string CPUTestFixture::GetCPUStateString( const json        &jsonData,
         {
             std::ostringstream oss;
             oss << std::hex << std::uppercase << std::setw( 2 ) << std::setfill( '0' )
-                << static_cast<int>( value ) << " (" << std::dec << static_cast<int>( value )
-                << ")";
+                << static_cast<int>( value ) << " (" << std::dec << static_cast<int>( value ) << ")";
             return oss.str();
         };
 

--- a/tests/rom_test.cpp
+++ b/tests/rom_test.cpp
@@ -21,9 +21,9 @@ using namespace std;
 
 TEST( RomTests, Nestest )
 {
-    PPU ppu;
-    Bus bus(&ppu);
-    CPU cpu( &bus );
+    Bus bus;
+    CPU cpu = bus.cpu;
+    PPU ppu = bus.ppu;
 
     // Create a shared pointer to Cartridge
     shared_ptr<Cartridge> cartridge = make_shared<Cartridge>( "tests/roms/nestest.nes" );


### PR DESCRIPTION
Closes #101

Building on what William submitted earlier:
- Refactored `bus.h` to initialize `CPU` and `PPU` internally instead of taking a pointer to these as arguments in the constructor. This allows for easier initialization and communication between each component through the shared bus parent.
- Created a skeleton for the `PPU` class with placeholders to implement further logic. It may seem like a big file, but there's a lot of isolated logic that can be implemented as individual tickets
- Adjusted nuances to how mirroring mode is set

The PPU is a pretty big component. The skeleton code covers most of the read/write communication logic between the inner registers, and some background rendering events. It doesn't cover sprite stuff yet, but sprite rendering can be implemented after background rendering.