### PR TITLE
ISC implementation with definition

### DIFF
--- a/include/cpu.h
+++ b/include/cpu.h
@@ -245,4 +245,5 @@ class CPU
     void SRE( u16 address );
     void RLA( u16 address );
     void DCP( u16 address );
+    void ISC( u16 address );
 };

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -323,7 +323,7 @@ CPU::CPU( Bus *bus ) : _bus( bus ), _opcodeTable{}
     _opcodeTable[0x23] = InstructionData{ "RLA_IndirectX", &CPU::RLA, &CPU::INDX, 8, 2 };
     _opcodeTable[0x33] = InstructionData{ "RLA_IndirectY", &CPU::RLA, &CPU::INDY, 8, 2, false };
 
-    // Illegal - DCP
+    // Illegal Opcode - DCP
     _opcodeTable[0xC7] = InstructionData{ "DCP_ZeroPage", &CPU::DCP, &CPU::ZPG, 5, 2 };
     _opcodeTable[0xD7] = InstructionData{ "DCP_ZeroPageX", &CPU::DCP, &CPU::ZPGX, 6, 2 };
     _opcodeTable[0xCF] = InstructionData{ "DCP_Absolute", &CPU::DCP, &CPU::ABS, 6, 3 };
@@ -331,6 +331,15 @@ CPU::CPU( Bus *bus ) : _bus( bus ), _opcodeTable{}
     _opcodeTable[0xDB] = InstructionData{ "DCP_AbsoluteY", &CPU::DCP, &CPU::ABSY, 7, 3, false };
     _opcodeTable[0xC3] = InstructionData{ "DCP_IndirectX", &CPU::DCP, &CPU::INDX, 8, 2 };
     _opcodeTable[0xD3] = InstructionData{ "DCP_IndirectY", &CPU::DCP, &CPU::INDY, 8, 2, false };
+
+    // Illegal Opcode - ISC
+    _opcodeTable[0xE7] = InstructionData{ "ISC_ZeroPage", &CPU::ISC, &CPU::ZPG, 5, 2 };
+    _opcodeTable[0xF7] = InstructionData{ "ISC_ZeroPageX", &CPU::ISC, &CPU::ZPGX, 6, 2 };
+    _opcodeTable[0xEF] = InstructionData{ "ISC_Absolute", &CPU::ISC, &CPU::ABS, 6, 3 };
+    _opcodeTable[0xFF] = InstructionData{ "ISC_AbsoluteX", &CPU::ISC, &CPU::ABSX, 7, 3, false };
+    _opcodeTable[0xFB] = InstructionData{ "ISC_AbsoluteY", &CPU::ISC, &CPU::ABSY, 7, 3, false };
+    _opcodeTable[0xE3] = InstructionData{ "ISC_IndirectX", &CPU::ISC, &CPU::INDX, 8, 2 };
+    _opcodeTable[0xF3] = InstructionData{ "ISC_IndirectY", &CPU::ISC, &CPU::INDY, 8, 2, false };
 };
 
 // Getters
@@ -2337,4 +2346,56 @@ void CPU::DCP( u16 address )
     }
 
     SetZeroAndNegativeFlags( result );
+}
+
+void CPU::ISC( const u16 address )
+{
+    /* @brief Illegal opcode: combines INC and SBC
+     * N Z C I D V
+     * + + + - - +
+     *   Usage and cycles:
+     *   ISC Zero Page: E7(5)
+     *   ISC Zero Page X: F7(6)
+     *   ISC Absolute: EF(6)
+     *   ISC Absolute X: FF(7)
+     *   ISC Absolute Y: FB(7)
+     *   ISC Indirect X: E3(8)
+     *   ISC Indirect Y: F3(8)
+     */
+
+    // read from memory
+    u8 value = Read( address );
+
+    // increment the value that was read
+    value = value + 1;
+    Write( address, value );
+
+    // complete SBC operation
+    u8 const carry = IsFlagSet( Status::Carry ) ? 0 : 1;
+    u8 const result = _a - value - carry;
+
+    // update the carry flag
+    if ( _a >= ( value + carry ) )
+    {
+        SetFlags( Carry );
+    }
+    else
+    {
+        ClearFlags( Carry );
+    }
+
+    // update the overflow flag
+    if ( ( ( _a ^ value ) & 0x80 ) && ( ( _a ^ result ) & 0x80 ) )
+    {
+        SetFlags( Overflow );
+    }
+    else
+    {
+        ClearFlags( Overflow );
+    }
+
+    // update accumulator
+    _a = result;
+
+    SetZeroAndNegativeFlags( _a );
 }

--- a/tests/cpu_test.cpp
+++ b/tests/cpu_test.cpp
@@ -701,13 +701,13 @@ CPU_TEST( C3, DCP, IndirectX, "c3.json" );
 CPU_TEST( D3, DCP, IndirectY, "d3.json" );
 
 /* Illegal ISC */
-// CPU_TEST( E7, ISC, ZeroPage, "e7.json" );
-// CPU_TEST( F7, ISC, ZeroPageX, "f7.json" );
-// CPU_TEST( EF, ISC, Absolute, "ef.json" );
-// CPU_TEST( FF, ISC, AbsoluteX, "ff.json" );
-// CPU_TEST( FB, ISC, AbsoluteY, "fb.json" );
-// CPU_TEST( E3, ISC, IndirectX, "e3.json" );
-// CPU_TEST( F3, ISC, IndirectY, "f3.json" );
+CPU_TEST( E7, ISC, ZeroPage, "e7.json" );
+CPU_TEST( F7, ISC, ZeroPageX, "f7.json" );
+CPU_TEST( EF, ISC, Absolute, "ef.json" );
+CPU_TEST( FF, ISC, AbsoluteX, "ff.json" );
+CPU_TEST( FB, ISC, AbsoluteY, "fb.json" );
+CPU_TEST( E3, ISC, IndirectX, "e3.json" );
+CPU_TEST( F3, ISC, IndirectY, "f3.json" );
 
 /* Illegal ALR */
 CPU_TEST( 4B, ALR, Immediate, "4b.json" );


### PR DESCRIPTION
Implemented ISC illegal opcode, adding a definition in the cpu.h and enabling the ISC tests in cpu_tests.cpp