### PR TITLE
Refactor: Better Cycle Accuracy and Passing Nestest ROM. 

### DIFF
--- a/include/ppu.h
+++ b/include/ppu.h
@@ -31,6 +31,7 @@ class PPU
     */
     void SetScanline( s16 scanline );
     void SetCycles( u16 cycles );
+    void SetIsCpuReadingPpuStatus( bool isReading );
 
     /*
     ################################
@@ -77,6 +78,7 @@ class PPU
     u16  _cycle = 4;
     u64  _frame = 1;
     bool _isRenderingEnabled = false;
+    bool _isCpuReadingPpuStatus = false;
 
     /*
     ################################

--- a/include/utils.h
+++ b/include/utils.h
@@ -1,10 +1,12 @@
 #pragma once
 
+#include <cstddef>
 #include <string>
 #include <cstdint>
 #include <unordered_set>
 #include <sstream>
 #include <regex>
+#include <vector>
 
 using u8 = std::uint8_t;
 using u16 = std::uint16_t;

--- a/include/utils.h
+++ b/include/utils.h
@@ -1,14 +1,14 @@
 #pragma once
 
-#include "cpu.h"
-#include <cstdint>
-#include <cstddef>
-#include <regex>
 #include <string>
-#include <vector>
+#include <cstdint>
+#include <unordered_set>
+#include <sstream>
+#include <regex>
 
 using u8 = std::uint8_t;
 using u16 = std::uint16_t;
+
 using namespace std;
 
 namespace utils
@@ -19,6 +19,14 @@ using MatchResults = std::vector<MatchResult>;
 MatchResult  parseLogLine( const std::string &line, const std::regex &pattern, std::size_t expectedMatches );
 MatchResults parseLog( const std::string &filename, const std::regex &pattern, std::size_t expectedMatches );
 
+/*
+################################
+||                            ||
+||       String Related       ||
+||                            ||
+################################
+* Various string related utilities
+*/
 inline std::string toHex( u16 num, u8 width = 4 )
 {
     /*
@@ -31,6 +39,89 @@ inline std::string toHex( u16 num, u8 width = 4 )
         hex_str[i] = "0123456789ABCDEF"[num & 0xF];
     }
     return hex_str;
+}
+
+/*
+################################
+||                            ||
+||  Address String Validator  ||
+||                            ||
+################################
+* Validates address mode strings in the lookup table (cpu.cpp)
+*/
+inline const std::unordered_set<std::string> &getAddrModeSet()
+{
+    static const std::unordered_set<std::string> addr_mode_set = {
+        "IMP", "IMM", "ZPG", "ZPGX", "ZPGY", "ABS", "ABSX", "ABSY", "IND", "INDX", "INDY", "REL" };
+    return addr_mode_set;
+}
+
+inline bool isValidAddrModeStr( const std::string &addr_mode )
+{
+    const auto &addr_mode_set = getAddrModeSet();
+    return addr_mode_set.find( addr_mode ) != addr_mode_set.end();
+}
+
+inline std::string getAvailableAddrModes()
+{
+    const auto        &addr_mode_set = getAddrModeSet();
+    std::ostringstream oss;
+    for ( const auto &addr_mode : addr_mode_set )
+    {
+        oss << addr_mode << ", ";
+    }
+    std::string result = oss.str();
+    if ( !result.empty() )
+    {
+        result.pop_back();
+        result.pop_back();
+    }
+    return result;
+}
+
+/*
+################################
+||                            ||
+||    Opcode Name Validator   ||
+||                            ||
+################################
+* Validates names defined in the opcode lookup table (cpu.cpp)
+*/
+inline const std::unordered_set<std::string> &getOpcodeNameSet()
+{
+    static const std::unordered_set<std::string> name_set = {
+        "ADC", "AND", "ASL", "BCC", "BCS", "BEQ", "BIT", "BMI", "BNE", "BPL", "BRK", "BVC", "BVS", "CLC",
+        "CLD", "CLI", "CLV", "CMP", "CPX", "CPY", "DEC", "DEX", "DEY", "EOR", "INC", "INX", "INY", "JMP",
+        "JSR", "LDA", "LDX", "LDY", "LSR", "NOP", "ORA", "PHA", "PHP", "PLA", "PLP", "ROL", "ROR", "RTI",
+        "RTS", "SBC", "SEC", "SED", "SEI", "STA", "STX", "STY", "TAX", "TAY", "TSX", "TXA", "TXS", "TYA",
+        // Illegal
+        "*ALR", "*ANC", "*ARR", "*DCP", "*ISC", "*JAM", "*LAX", "*LXA", "*NOP", "*RLA", "*RRA", "*SAX",
+        "*SBC", "*SBX", "*SLO", "*SRE" };
+    return name_set;
+}
+
+inline bool isValidOpcodeName( const std::string &name )
+{
+    const auto &name_set = getOpcodeNameSet();
+    return name_set.find( name ) != name_set.end();
+}
+
+inline std::string getAvailableOpcodeNames()
+{
+    const auto        &name_set = getOpcodeNameSet();
+    std::ostringstream oss;
+    for ( const auto &name : name_set )
+    {
+        oss << name << ", ";
+    }
+    std::string result = oss.str();
+    // Remove trailing comma and space
+    if ( !result.empty() )
+    {
+        result.pop_back();
+        result.pop_back();
+    }
+    return result;
 }
 
 } // namespace utils

--- a/src/bus.cpp
+++ b/src/bus.cpp
@@ -12,6 +12,11 @@ Bus::Bus( const bool use_flat_memory ) : cpu( this ), ppu( this ), _use_flat_mem
     _apu_io_memory.fill( 0 );
 }
 
+/*
+################################
+||          CPU Read          ||
+################################
+*/
 u8 Bus::Read( const u16 address )
 {
     if ( _use_flat_memory )
@@ -52,6 +57,11 @@ u8 Bus::Read( const u16 address )
     return 0xFF;
 }
 
+/*
+################################
+||          CPU Write         ||
+################################
+*/
 void Bus::Write( const u16 address, const u8 data )
 {
     if ( _use_flat_memory )
@@ -100,7 +110,19 @@ void Bus::Write( const u16 address, const u8 data )
     std::cout << "Unhandled write to address: " << std::hex << address << "\n";
 }
 
+/*
+################################
+||       Load Cartridge       ||
+################################
+*/
 void Bus::LoadCartridge( std::shared_ptr<Cartridge> loaded_cartridge )
 {
     cartridge = std::move( loaded_cartridge );
 }
+
+/*
+################################
+||        Debug Methods       ||
+################################
+*/
+[[nodiscard]] bool Bus::IsTestMode() const { return _use_flat_memory; }

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -3,6 +3,7 @@
 #include "bus.h"
 #include "cpu.h"
 #include "utils.h"
+#include <cstdint>
 #include <string>
 #include <iostream>
 #include <stdexcept>
@@ -446,8 +447,8 @@ std::string CPU::LogLineAtPC( bool verbose ) // NOLINT
      */
     std::string output;
 
-    std::string name = _opcodeTable[Read( _pc )].name;
-    std::string addr_mode = _opcodeTable[Read( _pc )].addr_mode;
+    std::string       name = _opcodeTable[Read( _pc )].name;
+    std::string const addr_mode = _opcodeTable[Read( _pc )].addr_mode;
 
     // Program counter address
     // i.e. FFFF
@@ -565,7 +566,7 @@ std::string CPU::LogLineAtPC( bool verbose ) // NOLINT
         output += registers_str + status_str;
 
         // Scanline num (V)
-        std::string scanline_str = std::to_string( _bus->ppu.GetScanline() );
+        std::string const scanline_str = std::to_string( _bus->ppu.GetScanline() );
         // std::string scanline_str_adjusted = std::string( 4 - scanline_str.size(), ' ' );
         output += "  V: " + scanline_str;
 
@@ -707,17 +708,17 @@ void CPU::NMI()
     StackPush( _pc & 0xFF );
 
     // 3) Push status register with B=0; bit 5 (Unused) = 1
-    u8 pushed_status = ( _p & ~Break ) | Unused;
+    u8 const pushed_status = ( _p & ~Break ) | Unused;
     StackPush( pushed_status );
 
     // 4) Fetch low byte of NMI vector ($FFFA)
-    u8 low = ReadAndTick( 0xFFFA );
+    u8 const low = ReadAndTick( 0xFFFA );
 
     // 5) Set I flag
     SetFlags( InterruptDisable );
 
     // 6) Fetch high byte of NMI vector ($FFFB)
-    u8 high = ReadAndTick( 0xFFFB );
+    u8 const high = ReadAndTick( 0xFFFB );
 
     // 7) Update PC
     _pc = static_cast<u16>( high ) << 8 | low;
@@ -736,11 +737,11 @@ void CPU::IRQ()
     Tick();
     StackPush( ( _pc >> 8 ) & 0xFF );
     StackPush( _pc & 0xFF );
-    u8 pushed_status = ( _p & ~Break ) | Unused;
+    u8 const pushed_status = ( _p & ~Break ) | Unused;
     StackPush( pushed_status );
-    u8 low = ReadAndTick( 0xFFFE );
+    u8 const low = ReadAndTick( 0xFFFE );
     SetFlags( InterruptDisable );
-    u8 high = ReadAndTick( 0xFFFF );
+    u8 const high = ReadAndTick( 0xFFFF );
     _pc = static_cast<u16>( high ) << 8 | low;
 }
 

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -3,350 +3,406 @@
 #include "bus.h"
 #include "cpu.h"
 #include "utils.h"
-#include <cstddef>
 #include <string>
 #include <iostream>
 #include <stdexcept>
 
 CPU::CPU( Bus *bus ) : _bus( bus ), _opcodeTable{}
 {
+
     /*
     ################################################################
     ||                                                            ||
-    ||                      Set Opcodes here                      ||
+    ||                           Opcodes                          ||
     ||                                                            ||
     ################################################################
     */
-
     // NOP
-    _opcodeTable[0xEA] = InstructionData{ "NOP_Implied", &CPU::NOP, &CPU::IMP, 2, 1 };
-
-    // Illegal - NOP
-    _opcodeTable[0x1A] = InstructionData{ "NOP_Implied", &CPU::NOP, &CPU::IMP, 2, 1 };
-    _opcodeTable[0x3A] = InstructionData{ "NOP_Implied", &CPU::NOP, &CPU::IMP, 2, 1 };
-    _opcodeTable[0x5A] = InstructionData{ "NOP_Implied", &CPU::NOP, &CPU::IMP, 2, 1 };
-    _opcodeTable[0x7A] = InstructionData{ "NOP_Implied", &CPU::NOP, &CPU::IMP, 2, 1 };
-    _opcodeTable[0xDA] = InstructionData{ "NOP_Implied", &CPU::NOP, &CPU::IMP, 2, 1 };
-    _opcodeTable[0xFA] = InstructionData{ "NOP_Implied", &CPU::NOP, &CPU::IMP, 2, 1 };
-    _opcodeTable[0x80] = InstructionData{ "NOP_Immediate", &CPU::NOP, &CPU::IMM, 2, 2 };
-    _opcodeTable[0x82] = InstructionData{ "NOP_Immediate", &CPU::NOP, &CPU::IMM, 2, 2 };
-    _opcodeTable[0x89] = InstructionData{ "NOP_Immediate", &CPU::NOP, &CPU::IMM, 2, 2 };
-    _opcodeTable[0xC2] = InstructionData{ "NOP_Immediate", &CPU::NOP, &CPU::IMM, 2, 2 };
-    _opcodeTable[0xE2] = InstructionData{ "NOP_Immediate", &CPU::NOP, &CPU::IMM, 2, 2 };
-    _opcodeTable[0x04] = InstructionData{ "NOP_ZeroPage", &CPU::NOP, &CPU::ZPG, 3, 2 };
-    _opcodeTable[0x44] = InstructionData{ "NOP_ZeroPage", &CPU::NOP, &CPU::ZPG, 3, 2 };
-    _opcodeTable[0x64] = InstructionData{ "NOP_ZeroPage", &CPU::NOP, &CPU::ZPG, 3, 2 };
-    _opcodeTable[0x14] = InstructionData{ "NOP_ZeroPageX", &CPU::NOP, &CPU::ZPGX, 4, 2 };
-    _opcodeTable[0x34] = InstructionData{ "NOP_ZeroPageX", &CPU::NOP, &CPU::ZPGX, 4, 2 };
-    _opcodeTable[0x54] = InstructionData{ "NOP_ZeroPageX", &CPU::NOP, &CPU::ZPGX, 4, 2 };
-    _opcodeTable[0x74] = InstructionData{ "NOP_ZeroPageX", &CPU::NOP, &CPU::ZPGX, 4, 2 };
-    _opcodeTable[0xD4] = InstructionData{ "NOP_ZeroPageX", &CPU::NOP, &CPU::ZPGX, 4, 2 };
-    _opcodeTable[0xF4] = InstructionData{ "NOP_ZeroPageX", &CPU::NOP, &CPU::ZPGX, 4, 2 };
-    _opcodeTable[0x0C] = InstructionData{ "NOP_Absolute", &CPU::NOP, &CPU::ABS, 4, 3 };
-    _opcodeTable[0x1C] = InstructionData{ "NOP_AbsoluteX", &CPU::NOP, &CPU::ABSX, 4, 3 };
-    _opcodeTable[0x3C] = InstructionData{ "NOP_AbsoluteX", &CPU::NOP, &CPU::ABSX, 4, 3 };
-    _opcodeTable[0x5C] = InstructionData{ "NOP_AbsoluteX", &CPU::NOP, &CPU::ABSX, 4, 3 };
-    _opcodeTable[0x7C] = InstructionData{ "NOP_AbsoluteX", &CPU::NOP, &CPU::ABSX, 4, 3 };
-    _opcodeTable[0xDC] = InstructionData{ "NOP_AbsoluteX", &CPU::NOP, &CPU::ABSX, 4, 3 };
-    _opcodeTable[0xFC] = InstructionData{ "NOP_AbsoluteX", &CPU::NOP, &CPU::ABSX, 4, 3 };
+    _opcodeTable[0xEA] = InstructionData{ "NOP", "IMM", &CPU::NOP, &CPU::IMP, 2, 1 };
 
     // LDA
-    _opcodeTable[0xA9] = InstructionData{ "LDA_Immediate", &CPU::LDA, &CPU::IMM, 2, 2 };
-    _opcodeTable[0xA5] = InstructionData{ "LDA_ZeroPage", &CPU::LDA, &CPU::ZPG, 3, 2 };
-    _opcodeTable[0xB5] = InstructionData{ "LDA_ZeroPageX", &CPU::LDA, &CPU::ZPGX, 4, 2 };
-    _opcodeTable[0xAD] = InstructionData{ "LDA_Absolute", &CPU::LDA, &CPU::ABS, 4, 3 };
-    _opcodeTable[0xBD] = InstructionData{ "LDA_AbsoluteX", &CPU::LDA, &CPU::ABSX, 4, 3 };
-    _opcodeTable[0xB9] = InstructionData{ "LDA_AbsoluteY", &CPU::LDA, &CPU::ABSY, 4, 3 };
-    _opcodeTable[0xA1] = InstructionData{ "LDA_IndirectX", &CPU::LDA, &CPU::INDX, 6, 2 };
-    _opcodeTable[0xB1] = InstructionData{ "LDA_IndirectY", &CPU::LDA, &CPU::INDY, 5, 2 };
+    _opcodeTable[0xA9] = InstructionData{ "LDA", "IMM", &CPU::LDA, &CPU::IMM, 2, 2 };
+    _opcodeTable[0xA5] = InstructionData{ "LDA", "ZPG", &CPU::LDA, &CPU::ZPG, 3, 2 };
+    _opcodeTable[0xB5] = InstructionData{ "LDA", "ZPGX", &CPU::LDA, &CPU::ZPGX, 4, 2 };
+    _opcodeTable[0xAD] = InstructionData{ "LDA", "ABS", &CPU::LDA, &CPU::ABS, 4, 3 };
+    _opcodeTable[0xBD] = InstructionData{ "LDA", "ABSX", &CPU::LDA, &CPU::ABSX, 4, 3 };
+    _opcodeTable[0xB9] = InstructionData{ "LDA", "ABSY", &CPU::LDA, &CPU::ABSY, 4, 3 };
+    _opcodeTable[0xA1] = InstructionData{ "LDA", "INDX", &CPU::LDA, &CPU::INDX, 6, 2 };
+    _opcodeTable[0xB1] = InstructionData{ "LDA", "INDY", &CPU::LDA, &CPU::INDY, 5, 2 };
 
     // LDX
-    _opcodeTable[0xA2] = InstructionData{ "LDX_Immediate", &CPU::LDX, &CPU::IMM, 2, 2 };
-    _opcodeTable[0xA6] = InstructionData{ "LDX_ZeroPage", &CPU::LDX, &CPU::ZPG, 3, 2 };
-    _opcodeTable[0xB6] = InstructionData{ "LDX_ZeroPageY", &CPU::LDX, &CPU::ZPGY, 4, 2 };
-    _opcodeTable[0xAE] = InstructionData{ "LDX_Absolute", &CPU::LDX, &CPU::ABS, 4, 3 };
-    _opcodeTable[0xBE] = InstructionData{ "LDX_AbsoluteY", &CPU::LDX, &CPU::ABSY, 4, 3 };
+    _opcodeTable[0xA2] = InstructionData{ "LDX", "IMM", &CPU::LDX, &CPU::IMM, 2, 2 };
+    _opcodeTable[0xA6] = InstructionData{ "LDX", "ZPG", &CPU::LDX, &CPU::ZPG, 3, 2 };
+    _opcodeTable[0xB6] = InstructionData{ "LDX", "ZPGY", &CPU::LDX, &CPU::ZPGY, 4, 2, true, true };
+    _opcodeTable[0xAE] = InstructionData{ "LDX", "ABS", &CPU::LDX, &CPU::ABS, 4, 3 };
+    _opcodeTable[0xBE] = InstructionData{ "LDX", "ABSY", &CPU::LDX, &CPU::ABSY, 4, 3 };
 
     // LDY
-    _opcodeTable[0xA0] = InstructionData{ "LDY_Immediate", &CPU::LDY, &CPU::IMM, 2, 2 };
-    _opcodeTable[0xA4] = InstructionData{ "LDY_ZeroPage", &CPU::LDY, &CPU::ZPG, 3, 2 };
-    _opcodeTable[0xB4] = InstructionData{ "LDY_ZeroPageX", &CPU::LDY, &CPU::ZPGX, 4, 2 };
-    _opcodeTable[0xAC] = InstructionData{ "LDY_Absolute", &CPU::LDY, &CPU::ABS, 4, 3 };
-    _opcodeTable[0xBC] = InstructionData{ "LDY_AbsoluteX", &CPU::LDY, &CPU::ABSX, 4, 3 };
+    _opcodeTable[0xA0] = InstructionData{ "LDY", "IMM", &CPU::LDY, &CPU::IMM, 2, 2 };
+    _opcodeTable[0xA4] = InstructionData{ "LDY", "ZPG", &CPU::LDY, &CPU::ZPG, 3, 2 };
+    _opcodeTable[0xB4] = InstructionData{ "LDY", "ZPGX", &CPU::LDY, &CPU::ZPGX, 4, 2 };
+    _opcodeTable[0xAC] = InstructionData{ "LDY", "ABS", &CPU::LDY, &CPU::ABS, 4, 3 };
+    _opcodeTable[0xBC] = InstructionData{ "LDY", "ABSX", &CPU::LDY, &CPU::ABSX, 4, 3 };
 
     // STA
-    _opcodeTable[0x85] = InstructionData{ "STA_ZeroPage", &CPU::STA, &CPU::ZPG, 3, 2 };
-    _opcodeTable[0x95] = InstructionData{ "STA_ZeroPageX", &CPU::STA, &CPU::ZPGX, 4, 2 };
-    _opcodeTable[0x8D] = InstructionData{ "STA_Absolute", &CPU::STA, &CPU::ABS, 4, 3 };
-    _opcodeTable[0x9D] = InstructionData{ "STA_AbsoluteX", &CPU::STA, &CPU::ABSX, 5, 3, false };
-    _opcodeTable[0x99] = InstructionData{ "STA_AbsoluteY", &CPU::STA, &CPU::ABSY, 5, 3, false };
-    _opcodeTable[0x81] = InstructionData{ "STA_IndirectX", &CPU::STA, &CPU::INDX, 6, 2, false };
-    _opcodeTable[0x91] = InstructionData{ "STA_IndirectY", &CPU::STA, &CPU::INDY, 6, 2, false };
+    _opcodeTable[0x85] = InstructionData{ "STA", "ZPG", &CPU::STA, &CPU::ZPG, 3, 2 };
+    _opcodeTable[0x95] = InstructionData{ "STA", "ZPGX", &CPU::STA, &CPU::ZPGX, 4, 2 };
+    _opcodeTable[0x8D] = InstructionData{ "STA", "ABS", &CPU::STA, &CPU::ABS, 4, 3 };
+    _opcodeTable[0x9D] = InstructionData{ "STA", "ABSX", &CPU::STA, &CPU::ABSX, 5, 3, false, true };
+    _opcodeTable[0x99] = InstructionData{ "STA", "ABSY", &CPU::STA, &CPU::ABSY, 5, 3, false, true };
+    _opcodeTable[0x81] = InstructionData{ "STA", "INDX", &CPU::STA, &CPU::INDX, 6, 2, false };
+    _opcodeTable[0x91] = InstructionData{ "STA", "INDY", &CPU::STA, &CPU::INDY, 6, 2, false, true };
 
     // STX
-    _opcodeTable[0x86] = InstructionData{ "STX_ZeroPage", &CPU::STX, &CPU::ZPG, 3, 2 };
-    _opcodeTable[0x96] = InstructionData{ "STX_ZeroPageY", &CPU::STX, &CPU::ZPGY, 4, 2 };
-    _opcodeTable[0x8E] = InstructionData{ "STX_Absolute", &CPU::STX, &CPU::ABS, 4, 3 };
+    _opcodeTable[0x86] = InstructionData{ "STX", "ZPG", &CPU::STX, &CPU::ZPG, 3, 2 };
+    _opcodeTable[0x96] = InstructionData{ "STX", "ZPGY", &CPU::STX, &CPU::ZPGY, 4, 2, true, true };
+    _opcodeTable[0x8E] = InstructionData{ "STX", "ABS", &CPU::STX, &CPU::ABS, 4, 3 };
 
     // STY
-    _opcodeTable[0x84] = InstructionData{ "STY_ZeroPage", &CPU::STY, &CPU::ZPG, 3, 2 };
-    _opcodeTable[0x94] = InstructionData{ "STY_ZeroPageX", &CPU::STY, &CPU::ZPGX, 4, 2 };
-    _opcodeTable[0x8C] = InstructionData{ "STY_Absolute", &CPU::STY, &CPU::ABS, 4, 3 };
+    _opcodeTable[0x84] = InstructionData{ "STY", "ZPG", &CPU::STY, &CPU::ZPG, 3, 2 };
+    _opcodeTable[0x94] = InstructionData{ "STY", "ZPGX", &CPU::STY, &CPU::ZPGX, 4, 2 };
+    _opcodeTable[0x8C] = InstructionData{ "STY", "ABS", &CPU::STY, &CPU::ABS, 4, 3 };
 
     // ADC
-    _opcodeTable[0x69] = InstructionData{ "ADC_Immediate", &CPU::ADC, &CPU::IMM, 2, 2 };
-    _opcodeTable[0x65] = InstructionData{ "ADC_ZeroPage", &CPU::ADC, &CPU::ZPG, 3, 2 };
-    _opcodeTable[0x75] = InstructionData{ "ADC_ZeroPageX", &CPU::ADC, &CPU::ZPGX, 4, 2 };
-    _opcodeTable[0x6D] = InstructionData{ "ADC_Absolute", &CPU::ADC, &CPU::ABS, 4, 3 };
-    _opcodeTable[0x7D] = InstructionData{ "ADC_AbsoluteX", &CPU::ADC, &CPU::ABSX, 4, 3 };
-    _opcodeTable[0x79] = InstructionData{ "ADC_AbsoluteY", &CPU::ADC, &CPU::ABSY, 4, 3 };
-    _opcodeTable[0x61] = InstructionData{ "ADC_IndirectX", &CPU::ADC, &CPU::INDX, 6, 2 };
-    _opcodeTable[0x71] = InstructionData{ "ADC_IndirectY", &CPU::ADC, &CPU::INDY, 5, 2 };
+    _opcodeTable[0x69] = InstructionData{ "ADC", "IMM", &CPU::ADC, &CPU::IMM, 2, 2 };
+    _opcodeTable[0x65] = InstructionData{ "ADC", "ZPG", &CPU::ADC, &CPU::ZPG, 3, 2 };
+    _opcodeTable[0x75] = InstructionData{ "ADC", "ZPGX", &CPU::ADC, &CPU::ZPGX, 4, 2 };
+    _opcodeTable[0x6D] = InstructionData{ "ADC", "ABS", &CPU::ADC, &CPU::ABS, 4, 3 };
+    _opcodeTable[0x7D] = InstructionData{ "ADC", "ABSX", &CPU::ADC, &CPU::ABSX, 4, 3 };
+    _opcodeTable[0x79] = InstructionData{ "ADC", "ABSY", &CPU::ADC, &CPU::ABSY, 4, 3 };
+    _opcodeTable[0x61] = InstructionData{ "ADC", "INDX", &CPU::ADC, &CPU::INDX, 6, 2 };
+    _opcodeTable[0x71] = InstructionData{ "ADC", "INDY", &CPU::ADC, &CPU::INDY, 5, 2 };
 
     // SBC
-    _opcodeTable[0xE9] = InstructionData{ "SBC_Immediate", &CPU::SBC, &CPU::IMM, 2, 2 };
-    _opcodeTable[0xE5] = InstructionData{ "SBC_ZeroPage", &CPU::SBC, &CPU::ZPG, 3, 2 };
-    _opcodeTable[0xF5] = InstructionData{ "SBC_ZeroPageX", &CPU::SBC, &CPU::ZPGX, 4, 2 };
-    _opcodeTable[0xED] = InstructionData{ "SBC_Absolute", &CPU::SBC, &CPU::ABS, 4, 3 };
-    _opcodeTable[0xFD] = InstructionData{ "SBC_AbsoluteX", &CPU::SBC, &CPU::ABSX, 4, 3 };
-    _opcodeTable[0xF9] = InstructionData{ "SBC_AbsoluteY", &CPU::SBC, &CPU::ABSY, 4, 3 };
-    _opcodeTable[0xE1] = InstructionData{ "SBC_IndirectX", &CPU::SBC, &CPU::INDX, 6, 2 };
-    _opcodeTable[0xF1] = InstructionData{ "SBC_IndirectY", &CPU::SBC, &CPU::INDY, 5, 2 };
-
-    // Illegal - SBC
-    _opcodeTable[0xEB] = InstructionData{ "SBC_Immediate", &CPU::SBC, &CPU::IMM, 2, 2 };
+    _opcodeTable[0xE9] = InstructionData{ "SBC", "IMM", &CPU::SBC, &CPU::IMM, 2, 2 };
+    _opcodeTable[0xE5] = InstructionData{ "SBC", "ZPG", &CPU::SBC, &CPU::ZPG, 3, 2 };
+    _opcodeTable[0xF5] = InstructionData{ "SBC", "ZPGX", &CPU::SBC, &CPU::ZPGX, 4, 2 };
+    _opcodeTable[0xED] = InstructionData{ "SBC", "ABS", &CPU::SBC, &CPU::ABS, 4, 3 };
+    _opcodeTable[0xFD] = InstructionData{ "SBC", "ABSX", &CPU::SBC, &CPU::ABSX, 4, 3 };
+    _opcodeTable[0xF9] = InstructionData{ "SBC", "ABSY", &CPU::SBC, &CPU::ABSY, 4, 3 };
+    _opcodeTable[0xE1] = InstructionData{ "SBC", "INDX", &CPU::SBC, &CPU::INDX, 6, 2 };
+    _opcodeTable[0xF1] = InstructionData{ "SBC", "INDY", &CPU::SBC, &CPU::INDY, 5, 2 };
 
     // INC
-    _opcodeTable[0xE6] = InstructionData{ "INC_ZeroPage", &CPU::INC, &CPU::ZPG, 5, 2 };
-    _opcodeTable[0xF6] = InstructionData{ "INC_ZeroPageX", &CPU::INC, &CPU::ZPGX, 6, 2 };
-    _opcodeTable[0xEE] = InstructionData{ "INC_Absolute", &CPU::INC, &CPU::ABS, 6, 3 };
-    _opcodeTable[0xFE] = InstructionData{ "INC_AbsoluteX", &CPU::INC, &CPU::ABSX, 7, 3, false };
+    _opcodeTable[0xE6] = InstructionData{ "INC", "ZPG", &CPU::INC, &CPU::ZPG, 5, 2 };
+    _opcodeTable[0xF6] = InstructionData{ "INC", "ZPGX", &CPU::INC, &CPU::ZPGX, 6, 2 };
+    _opcodeTable[0xEE] = InstructionData{ "INC", "ABS", &CPU::INC, &CPU::ABS, 6, 3 };
+    _opcodeTable[0xFE] = InstructionData{ "INC", "ABSX", &CPU::INC, &CPU::ABSX, 7, 3, false, true };
 
     // DEC
-    _opcodeTable[0xC6] = InstructionData{ "DEC_ZeroPage", &CPU::DEC, &CPU::ZPG, 5, 2 };
-    _opcodeTable[0xD6] = InstructionData{ "DEC_ZeroPageX", &CPU::DEC, &CPU::ZPGX, 6, 2 };
-    _opcodeTable[0xCE] = InstructionData{ "DEC_Absolute", &CPU::DEC, &CPU::ABS, 6, 3 };
-    _opcodeTable[0xDE] = InstructionData{ "DEC_AbsoluteX", &CPU::DEC, &CPU::ABSX, 7, 3, false };
+    _opcodeTable[0xC6] = InstructionData{ "DEC", "ZPG", &CPU::DEC, &CPU::ZPG, 5, 2 };
+    _opcodeTable[0xD6] = InstructionData{ "DEC", "ZPGX", &CPU::DEC, &CPU::ZPGX, 6, 2 };
+    _opcodeTable[0xCE] = InstructionData{ "DEC", "ABS", &CPU::DEC, &CPU::ABS, 6, 3 };
+    _opcodeTable[0xDE] = InstructionData{ "DEC", "ABSX", &CPU::DEC, &CPU::ABSX, 7, 3, false, true };
 
     // INX, INY, DEX, DEY
-    _opcodeTable[0xE8] = InstructionData{ "INX_Implied", &CPU::INX, &CPU::IMP, 2, 1 };
-    _opcodeTable[0xC8] = InstructionData{ "INY_Implied", &CPU::INY, &CPU::IMP, 2, 1 };
-    _opcodeTable[0xCA] = InstructionData{ "DEX_Implied", &CPU::DEX, &CPU::IMP, 2, 1 };
-    _opcodeTable[0x88] = InstructionData{ "DEY_Implied", &CPU::DEY, &CPU::IMP, 2, 1 };
+    _opcodeTable[0xE8] = InstructionData{ "INX", "IMP", &CPU::INX, &CPU::IMP, 2, 1 };
+    _opcodeTable[0xC8] = InstructionData{ "INY", "IMP", &CPU::INY, &CPU::IMP, 2, 1 };
+    _opcodeTable[0xCA] = InstructionData{ "DEX", "IMP", &CPU::DEX, &CPU::IMP, 2, 1 };
+    _opcodeTable[0x88] = InstructionData{ "DEY", "IMP", &CPU::DEY, &CPU::IMP, 2, 1 };
 
     // CLC
-    _opcodeTable[0x18] = InstructionData{ "CLC_Implied", &CPU::CLC, &CPU::IMP, 2, 1 };
-    _opcodeTable[0x58] = InstructionData{ "CLI_Implied", &CPU::CLI, &CPU::IMP, 2, 1 };
-    _opcodeTable[0xD8] = InstructionData{ "CLD_Implied", &CPU::CLD, &CPU::IMP, 2, 1 };
-    _opcodeTable[0xB8] = InstructionData{ "CLV_Implied", &CPU::CLV, &CPU::IMP, 2, 1 };
+    _opcodeTable[0x18] = InstructionData{ "CLC", "IMP", &CPU::CLC, &CPU::IMP, 2, 1 };
+    _opcodeTable[0x58] = InstructionData{ "CLI", "IMP", &CPU::CLI, &CPU::IMP, 2, 1 };
+    _opcodeTable[0xD8] = InstructionData{ "CLD", "IMP", &CPU::CLD, &CPU::IMP, 2, 1 };
+    _opcodeTable[0xB8] = InstructionData{ "CLV", "IMP", &CPU::CLV, &CPU::IMP, 2, 1 };
 
-    _opcodeTable[0x38] = InstructionData{ "SEC_Implied", &CPU::SEC, &CPU::IMP, 2, 1 };
-    _opcodeTable[0x78] = InstructionData{ "SEI_Implied", &CPU::SEI, &CPU::IMP, 2, 1 };
-    _opcodeTable[0xF8] = InstructionData{ "SED_Implied", &CPU::SED, &CPU::IMP, 2, 1 };
+    // SEC, SEI, SED
+    _opcodeTable[0x38] = InstructionData{ "SEC", "IMP", &CPU::SEC, &CPU::IMP, 2, 1 };
+    _opcodeTable[0x78] = InstructionData{ "SEI", "IMP", &CPU::SEI, &CPU::IMP, 2, 1 };
+    _opcodeTable[0xF8] = InstructionData{ "SED", "IMP", &CPU::SED, &CPU::IMP, 2, 1 };
 
     // Branch
-    _opcodeTable[0x10] = InstructionData{ "BPL_Relative", &CPU::BPL, &CPU::REL, 2, 2 };
-    _opcodeTable[0x30] = InstructionData{ "BMI_Relative", &CPU::BMI, &CPU::REL, 2, 2 };
-    _opcodeTable[0x50] = InstructionData{ "BVC_Relative", &CPU::BVC, &CPU::REL, 2, 2 };
-    _opcodeTable[0x70] = InstructionData{ "BVS_Relative", &CPU::BVS, &CPU::REL, 2, 2 };
-    _opcodeTable[0x90] = InstructionData{ "BCC_Relative", &CPU::BCC, &CPU::REL, 2, 2 };
-    _opcodeTable[0xB0] = InstructionData{ "BCS_Relative", &CPU::BCS, &CPU::REL, 2, 2 };
-    _opcodeTable[0xD0] = InstructionData{ "BNE_Relative", &CPU::BNE, &CPU::REL, 2, 2 };
-    _opcodeTable[0xF0] = InstructionData{ "BEQ_Relative", &CPU::BEQ, &CPU::REL, 2, 2 };
+    _opcodeTable[0x10] = InstructionData{ "BPL", "REL", &CPU::BPL, &CPU::REL, 2, 2 };
+    _opcodeTable[0x30] = InstructionData{ "BMI", "REL", &CPU::BMI, &CPU::REL, 2, 2 };
+    _opcodeTable[0x50] = InstructionData{ "BVC", "REL", &CPU::BVC, &CPU::REL, 2, 2 };
+    _opcodeTable[0x70] = InstructionData{ "BVS", "REL", &CPU::BVS, &CPU::REL, 2, 2 };
+    _opcodeTable[0x90] = InstructionData{ "BCC", "REL", &CPU::BCC, &CPU::REL, 2, 2 };
+    _opcodeTable[0xB0] = InstructionData{ "BCS", "REL", &CPU::BCS, &CPU::REL, 2, 2 };
+    _opcodeTable[0xD0] = InstructionData{ "BNE", "REL", &CPU::BNE, &CPU::REL, 2, 2 };
+    _opcodeTable[0xF0] = InstructionData{ "BEQ", "REL", &CPU::BEQ, &CPU::REL, 2, 2 };
 
     // CMP, CPX, CPY
-    _opcodeTable[0xC9] = InstructionData{ "CMP_Immediate", &CPU::CMP, &CPU::IMM, 2, 2 };
-    _opcodeTable[0xC5] = InstructionData{ "CMP_ZeroPage", &CPU::CMP, &CPU::ZPG, 3, 2 };
-    _opcodeTable[0xD5] = InstructionData{ "CMP_ZeroPageX", &CPU::CMP, &CPU::ZPGX, 4, 2 };
-    _opcodeTable[0xCD] = InstructionData{ "CMP_Absolute", &CPU::CMP, &CPU::ABS, 4, 3 };
-    _opcodeTable[0xDD] = InstructionData{ "CMP_AbsoluteX", &CPU::CMP, &CPU::ABSX, 4, 3 };
-    _opcodeTable[0xD9] = InstructionData{ "CMP_AbsoluteY", &CPU::CMP, &CPU::ABSY, 4, 3 };
-    _opcodeTable[0xC1] = InstructionData{ "CMP_IndirectX", &CPU::CMP, &CPU::INDX, 6, 2 };
-    _opcodeTable[0xD1] = InstructionData{ "CMP_IndirectY", &CPU::CMP, &CPU::INDY, 5, 2 };
-    _opcodeTable[0xE0] = InstructionData{ "CPX_Immediate", &CPU::CPX, &CPU::IMM, 2, 2 };
-    _opcodeTable[0xE4] = InstructionData{ "CPX_ZeroPage", &CPU::CPX, &CPU::ZPG, 3, 2 };
-    _opcodeTable[0xEC] = InstructionData{ "CPX_Absolute", &CPU::CPX, &CPU::ABS, 4, 3 };
-    _opcodeTable[0xC0] = InstructionData{ "CPY_Immediate", &CPU::CPY, &CPU::IMM, 2, 2 };
-    _opcodeTable[0xC4] = InstructionData{ "CPY_ZeroPage", &CPU::CPY, &CPU::ZPG, 3, 2 };
-    _opcodeTable[0xCC] = InstructionData{ "CPY_Absolute", &CPU::CPY, &CPU::ABS, 4, 3 };
+    _opcodeTable[0xC9] = InstructionData{ "CMP", "IMM", &CPU::CMP, &CPU::IMM, 2, 2 };
+    _opcodeTable[0xC5] = InstructionData{ "CMP", "ZPG", &CPU::CMP, &CPU::ZPG, 3, 2 };
+    _opcodeTable[0xD5] = InstructionData{ "CMP", "ZPGX", &CPU::CMP, &CPU::ZPGX, 4, 2 };
+    _opcodeTable[0xCD] = InstructionData{ "CMP", "ABS", &CPU::CMP, &CPU::ABS, 4, 3 };
+    _opcodeTable[0xDD] = InstructionData{ "CMP", "ABSX", &CPU::CMP, &CPU::ABSX, 4, 3 };
+    _opcodeTable[0xD9] = InstructionData{ "CMP", "ABSY", &CPU::CMP, &CPU::ABSY, 4, 3 };
+    _opcodeTable[0xC1] = InstructionData{ "CMP", "INDX", &CPU::CMP, &CPU::INDX, 6, 2 };
+    _opcodeTable[0xD1] = InstructionData{ "CMP", "INDY", &CPU::CMP, &CPU::INDY, 5, 2 };
+    _opcodeTable[0xE0] = InstructionData{ "CPX", "IMM", &CPU::CPX, &CPU::IMM, 2, 2 };
+    _opcodeTable[0xE4] = InstructionData{ "CPX", "ZPG", &CPU::CPX, &CPU::ZPG, 3, 2 };
+    _opcodeTable[0xEC] = InstructionData{ "CPX", "ABS", &CPU::CPX, &CPU::ABS, 4, 3 };
+    _opcodeTable[0xC0] = InstructionData{ "CPY", "IMM", &CPU::CPY, &CPU::IMM, 2, 2 };
+    _opcodeTable[0xC4] = InstructionData{ "CPY", "ZPG", &CPU::CPY, &CPU::ZPG, 3, 2 };
+    _opcodeTable[0xCC] = InstructionData{ "CPY", "ABS", &CPU::CPY, &CPU::ABS, 4, 3 };
 
     // PHA, PHP, PLA, PLP, TSX, TXS
-    _opcodeTable[0x48] = InstructionData{ "PHA_Implied", &CPU::PHA, &CPU::IMP, 3, 1 };
-    _opcodeTable[0x08] = InstructionData{ "PHP_Implied", &CPU::PHP, &CPU::IMP, 3, 1 };
-    _opcodeTable[0x68] = InstructionData{ "PLA_Implied", &CPU::PLA, &CPU::IMP, 4, 1 };
-    _opcodeTable[0x28] = InstructionData{ "PLP_Implied", &CPU::PLP, &CPU::IMP, 4, 1 };
-    _opcodeTable[0xBA] = InstructionData{ "TSX_Implied", &CPU::TSX, &CPU::IMP, 2, 1 };
-    _opcodeTable[0x9A] = InstructionData{ "TXS_Implied", &CPU::TXS, &CPU::IMP, 2, 1 };
+    _opcodeTable[0x48] = InstructionData{ "PHA", "IMP", &CPU::PHA, &CPU::IMP, 3, 1 };
+    _opcodeTable[0x08] = InstructionData{ "PHP", "IMP", &CPU::PHP, &CPU::IMP, 3, 1 };
+    _opcodeTable[0x68] = InstructionData{ "PLA", "IMP", &CPU::PLA, &CPU::IMP, 4, 1 };
+    _opcodeTable[0x28] = InstructionData{ "PLP", "IMP", &CPU::PLP, &CPU::IMP, 4, 1 };
+    _opcodeTable[0xBA] = InstructionData{ "TSX", "IMP", &CPU::TSX, &CPU::IMP, 2, 1 };
+    _opcodeTable[0x9A] = InstructionData{ "TXS", "IMP", &CPU::TXS, &CPU::IMP, 2, 1 };
 
     // ASL, LSR
-    _opcodeTable[0x0A] = InstructionData{ "ASL_Implied", &CPU::ASL, &CPU::IMP, 2, 1 };
-    _opcodeTable[0x06] = InstructionData{ "ASL_ZeroPage", &CPU::ASL, &CPU::ZPG, 5, 2 };
-    _opcodeTable[0x16] = InstructionData{ "ASL_ZeroPageX", &CPU::ASL, &CPU::ZPGX, 6, 2 };
-    _opcodeTable[0x0E] = InstructionData{ "ASL_Absolute", &CPU::ASL, &CPU::ABS, 6, 3 };
-    _opcodeTable[0x1E] = InstructionData{ "ASL_AbsoluteX", &CPU::ASL, &CPU::ABSX, 7, 3, false };
-    _opcodeTable[0x4A] = InstructionData{ "LSR_Implied", &CPU::LSR, &CPU::IMP, 2, 1 };
-    _opcodeTable[0x46] = InstructionData{ "LSR_ZeroPage", &CPU::LSR, &CPU::ZPG, 5, 2 };
-    _opcodeTable[0x56] = InstructionData{ "LSR_ZeroPageX", &CPU::LSR, &CPU::ZPGX, 6, 2 };
-    _opcodeTable[0x4E] = InstructionData{ "LSR_Absolute", &CPU::LSR, &CPU::ABS, 6, 3 };
-    _opcodeTable[0x5E] = InstructionData{ "LSR_AbsoluteX", &CPU::LSR, &CPU::ABSX, 7, 3, false };
+    _opcodeTable[0x0A] = InstructionData{ "ASL", "IMP", &CPU::ASL, &CPU::IMP, 2, 1 };
+    _opcodeTable[0x06] = InstructionData{ "ASL", "ZPG", &CPU::ASL, &CPU::ZPG, 5, 2 };
+    _opcodeTable[0x16] = InstructionData{ "ASL", "ZPGX", &CPU::ASL, &CPU::ZPGX, 6, 2 };
+    _opcodeTable[0x0E] = InstructionData{ "ASL", "ABS", &CPU::ASL, &CPU::ABS, 6, 3 };
+    _opcodeTable[0x1E] = InstructionData{ "ASL", "ABSX", &CPU::ASL, &CPU::ABSX, 7, 3, false, true };
+    _opcodeTable[0x4A] = InstructionData{ "LSR", "IMP", &CPU::LSR, &CPU::IMP, 2, 1 };
+    _opcodeTable[0x46] = InstructionData{ "LSR", "ZPG", &CPU::LSR, &CPU::ZPG, 5, 2 };
+    _opcodeTable[0x56] = InstructionData{ "LSR", "ZPGX", &CPU::LSR, &CPU::ZPGX, 6, 2 };
+    _opcodeTable[0x4E] = InstructionData{ "LSR", "ABS", &CPU::LSR, &CPU::ABS, 6, 3 };
+    _opcodeTable[0x5E] = InstructionData{ "LSR", "ABSX", &CPU::LSR, &CPU::ABSX, 7, 3, false, true };
 
     // ROL, ROR
-    _opcodeTable[0x2A] = InstructionData{ "ROL_Implied", &CPU::ROL, &CPU::IMP, 2, 1 };
-    _opcodeTable[0x26] = InstructionData{ "ROL_ZeroPage", &CPU::ROL, &CPU::ZPG, 5, 2 };
-    _opcodeTable[0x36] = InstructionData{ "ROL_ZeroPageX", &CPU::ROL, &CPU::ZPGX, 6, 2 };
-    _opcodeTable[0x2E] = InstructionData{ "ROL_Absolute", &CPU::ROL, &CPU::ABS, 6, 3 };
-    _opcodeTable[0x3E] = InstructionData{ "ROL_AbsoluteX", &CPU::ROL, &CPU::ABSX, 7, 3, false };
-    _opcodeTable[0x6A] = InstructionData{ "ROR_Implied", &CPU::ROR, &CPU::IMP, 2, 1 };
-    _opcodeTable[0x66] = InstructionData{ "ROR_ZeroPage", &CPU::ROR, &CPU::ZPG, 5, 2 };
-    _opcodeTable[0x76] = InstructionData{ "ROR_ZeroPageX", &CPU::ROR, &CPU::ZPGX, 6, 2 };
-    _opcodeTable[0x6E] = InstructionData{ "ROR_Absolute", &CPU::ROR, &CPU::ABS, 6, 3 };
-    _opcodeTable[0x7E] = InstructionData{ "ROR_AbsoluteX", &CPU::ROR, &CPU::ABSX, 7, 3, false };
+    _opcodeTable[0x2A] = InstructionData{ "ROL", "IMP", &CPU::ROL, &CPU::IMP, 2, 1 };
+    _opcodeTable[0x26] = InstructionData{ "ROL", "ZPG", &CPU::ROL, &CPU::ZPG, 5, 2 };
+    _opcodeTable[0x36] = InstructionData{ "ROL", "ZPGX", &CPU::ROL, &CPU::ZPGX, 6, 2 };
+    _opcodeTable[0x2E] = InstructionData{ "ROL", "ABS", &CPU::ROL, &CPU::ABS, 6, 3 };
+    _opcodeTable[0x3E] = InstructionData{ "ROL", "ABSX", &CPU::ROL, &CPU::ABSX, 7, 3, false, true };
+    _opcodeTable[0x6A] = InstructionData{ "ROR", "IMP", &CPU::ROR, &CPU::IMP, 2, 1 };
+    _opcodeTable[0x66] = InstructionData{ "ROR", "ZPG", &CPU::ROR, &CPU::ZPG, 5, 2 };
+    _opcodeTable[0x76] = InstructionData{ "ROR", "ZPGX", &CPU::ROR, &CPU::ZPGX, 6, 2 };
+    _opcodeTable[0x6E] = InstructionData{ "ROR", "ABS", &CPU::ROR, &CPU::ABS, 6, 3 };
+    _opcodeTable[0x7E] = InstructionData{ "ROR", "ABSX", &CPU::ROR, &CPU::ABSX, 7, 3, false, true };
 
     // JMP JSR, RTS, RTI, BRK
-    _opcodeTable[0x4C] = InstructionData{ "JMP_Absolute", &CPU::JMP, &CPU::ABS, 3, 3 };
-    _opcodeTable[0x6C] = InstructionData{ "JMP_Indirect", &CPU::JMP, &CPU::IND, 5, 3 };
-    _opcodeTable[0x20] = InstructionData{ "JSR_Absolute", &CPU::JSR, &CPU::ABS, 6, 3 };
-    _opcodeTable[0x60] = InstructionData{ "RTS_Implied", &CPU::RTS, &CPU::IMP, 6, 1 };
-    _opcodeTable[0x40] = InstructionData{ "RTI_Implied", &CPU::RTI, &CPU::IMP, 6, 1 };
-    _opcodeTable[0x00] = InstructionData{ "BRK_Implied", &CPU::BRK, &CPU::IMP, 7, 1 };
+    _opcodeTable[0x4C] = InstructionData{ "JMP", "ABS", &CPU::JMP, &CPU::ABS, 3, 3 };
+    _opcodeTable[0x6C] = InstructionData{ "JMP", "IND", &CPU::JMP, &CPU::IND, 5, 3 };
+    _opcodeTable[0x20] = InstructionData{ "JSR", "ABS", &CPU::JSR, &CPU::ABS, 6, 3 };
+    _opcodeTable[0x60] = InstructionData{ "RTS", "IMP", &CPU::RTS, &CPU::IMP, 6, 1 };
+    _opcodeTable[0x40] = InstructionData{ "RTI", "IMP", &CPU::RTI, &CPU::IMP, 6, 1 };
+    _opcodeTable[0x00] = InstructionData{ "BRK", "IMP", &CPU::BRK, &CPU::IMP, 7, 1 };
 
     // AND
-    _opcodeTable[0x29] = InstructionData{ "AND_Immediate", &CPU::AND, &CPU::IMM, 2, 2 };
-    _opcodeTable[0x25] = InstructionData{ "AND_ZeroPage", &CPU::AND, &CPU::ZPG, 3, 2 };
-    _opcodeTable[0x35] = InstructionData{ "AND_ZeroPageX", &CPU::AND, &CPU::ZPGX, 4, 2 };
-    _opcodeTable[0x2D] = InstructionData{ "AND_Absolute", &CPU::AND, &CPU::ABS, 4, 3 };
-    _opcodeTable[0x3D] = InstructionData{ "AND_AbsoluteX", &CPU::AND, &CPU::ABSX, 4, 3 };
-    _opcodeTable[0x39] = InstructionData{ "AND_AbsoluteY", &CPU::AND, &CPU::ABSY, 4, 3 };
-    _opcodeTable[0x21] = InstructionData{ "AND_IndirectX", &CPU::AND, &CPU::INDX, 6, 2 };
-    _opcodeTable[0x31] = InstructionData{ "AND_IndirectY", &CPU::AND, &CPU::INDY, 5, 2 };
+    _opcodeTable[0x29] = InstructionData{ "AND", "IMM", &CPU::AND, &CPU::IMM, 2, 2 };
+    _opcodeTable[0x25] = InstructionData{ "AND", "ZPG", &CPU::AND, &CPU::ZPG, 3, 2 };
+    _opcodeTable[0x35] = InstructionData{ "AND", "ZPGX", &CPU::AND, &CPU::ZPGX, 4, 2 };
+    _opcodeTable[0x2D] = InstructionData{ "AND", "ABS", &CPU::AND, &CPU::ABS, 4, 3 };
+    _opcodeTable[0x3D] = InstructionData{ "AND", "ABSX", &CPU::AND, &CPU::ABSX, 4, 3 };
+    _opcodeTable[0x39] = InstructionData{ "AND", "ABSY", &CPU::AND, &CPU::ABSY, 4, 3 };
+    _opcodeTable[0x21] = InstructionData{ "AND", "INDX", &CPU::AND, &CPU::INDX, 6, 2 };
+    _opcodeTable[0x31] = InstructionData{ "AND", "INDY", &CPU::AND, &CPU::INDY, 5, 2 };
 
     // ORA
-    _opcodeTable[0x09] = InstructionData{ "ORA_Immediate", &CPU::ORA, &CPU::IMM, 2, 2 };
-    _opcodeTable[0x05] = InstructionData{ "ORA_ZeroPage", &CPU::ORA, &CPU::ZPG, 3, 2 };
-    _opcodeTable[0x15] = InstructionData{ "ORA_ZeroPageX", &CPU::ORA, &CPU::ZPGX, 4, 2 };
-    _opcodeTable[0x0D] = InstructionData{ "ORA_Absolute", &CPU::ORA, &CPU::ABS, 4, 3 };
-    _opcodeTable[0x1D] = InstructionData{ "ORA_AbsoluteX", &CPU::ORA, &CPU::ABSX, 4, 3 };
-    _opcodeTable[0x19] = InstructionData{ "ORA_AbsoluteY", &CPU::ORA, &CPU::ABSY, 4, 3 };
-    _opcodeTable[0x01] = InstructionData{ "ORA_IndirectX", &CPU::ORA, &CPU::INDX, 6, 2 };
-    _opcodeTable[0x11] = InstructionData{ "ORA_IndirectY", &CPU::ORA, &CPU::INDY, 5, 2 };
+    _opcodeTable[0x09] = InstructionData{ "ORA", "IMM", &CPU::ORA, &CPU::IMM, 2, 2 };
+    _opcodeTable[0x05] = InstructionData{ "ORA", "ZPG", &CPU::ORA, &CPU::ZPG, 3, 2 };
+    _opcodeTable[0x15] = InstructionData{ "ORA", "ZPGX", &CPU::ORA, &CPU::ZPGX, 4, 2 };
+    _opcodeTable[0x0D] = InstructionData{ "ORA", "ABS", &CPU::ORA, &CPU::ABS, 4, 3 };
+    _opcodeTable[0x1D] = InstructionData{ "ORA", "ABSX", &CPU::ORA, &CPU::ABSX, 4, 3 };
+    _opcodeTable[0x19] = InstructionData{ "ORA", "ABSY", &CPU::ORA, &CPU::ABSY, 4, 3 };
+    _opcodeTable[0x01] = InstructionData{ "ORA", "INDX", &CPU::ORA, &CPU::INDX, 6, 2 };
+    _opcodeTable[0x11] = InstructionData{ "ORA", "INDY", &CPU::ORA, &CPU::INDY, 5, 2 };
 
     // EOR
-    _opcodeTable[0x49] = InstructionData{ "EOR_Immediate", &CPU::EOR, &CPU::IMM, 2, 2 };
-    _opcodeTable[0x45] = InstructionData{ "EOR_ZeroPage", &CPU::EOR, &CPU::ZPG, 3, 2 };
-    _opcodeTable[0x55] = InstructionData{ "EOR_ZeroPageX", &CPU::EOR, &CPU::ZPGX, 4, 2 };
-    _opcodeTable[0x4D] = InstructionData{ "EOR_Absolute", &CPU::EOR, &CPU::ABS, 4, 3 };
-    _opcodeTable[0x5D] = InstructionData{ "EOR_AbsoluteX", &CPU::EOR, &CPU::ABSX, 4, 3 };
-    _opcodeTable[0x59] = InstructionData{ "EOR_AbsoluteY", &CPU::EOR, &CPU::ABSY, 4, 3 };
-    _opcodeTable[0x41] = InstructionData{ "EOR_IndirectX", &CPU::EOR, &CPU::INDX, 6, 2 };
-    _opcodeTable[0x51] = InstructionData{ "EOR_IndirectY", &CPU::EOR, &CPU::INDY, 5, 2 };
+    _opcodeTable[0x49] = InstructionData{ "EOR", "IMM", &CPU::EOR, &CPU::IMM, 2, 2 };
+    _opcodeTable[0x45] = InstructionData{ "EOR", "ZPG", &CPU::EOR, &CPU::ZPG, 3, 2 };
+    _opcodeTable[0x55] = InstructionData{ "EOR", "ZPGX", &CPU::EOR, &CPU::ZPGX, 4, 2 };
+    _opcodeTable[0x4D] = InstructionData{ "EOR", "ABS", &CPU::EOR, &CPU::ABS, 4, 3 };
+    _opcodeTable[0x5D] = InstructionData{ "EOR", "ABSX", &CPU::EOR, &CPU::ABSX, 4, 3 };
+    _opcodeTable[0x59] = InstructionData{ "EOR", "ABSY", &CPU::EOR, &CPU::ABSY, 4, 3 };
+    _opcodeTable[0x41] = InstructionData{ "EOR", "INDX", &CPU::EOR, &CPU::INDX, 6, 2 };
+    _opcodeTable[0x51] = InstructionData{ "EOR", "INDY", &CPU::EOR, &CPU::INDY, 5, 2 };
 
     // BIT
-    _opcodeTable[0x24] = InstructionData{ "BIT_ZeroPage", &CPU::BIT, &CPU::ZPG, 3, 2 };
-    _opcodeTable[0x2C] = InstructionData{ "BIT_Absolute", &CPU::BIT, &CPU::ABS, 4, 3 };
+    _opcodeTable[0x24] = InstructionData{ "BIT", "ZPG", &CPU::BIT, &CPU::ZPG, 3, 2 };
+    _opcodeTable[0x2C] = InstructionData{ "BIT", "ABS", &CPU::BIT, &CPU::ABS, 4, 3 };
 
     // Transfer
-    _opcodeTable[0xAA] = InstructionData{ "TAX_Implied", &CPU::TAX, &CPU::IMP, 2, 1 };
-    _opcodeTable[0x8A] = InstructionData{ "TXA_Implied", &CPU::TXA, &CPU::IMP, 2, 1 };
-    _opcodeTable[0xA8] = InstructionData{ "TAY_Implied", &CPU::TAY, &CPU::IMP, 2, 1 };
-    _opcodeTable[0x98] = InstructionData{ "TYA_Implied", &CPU::TYA, &CPU::IMP, 2, 1 };
+    _opcodeTable[0xAA] = InstructionData{ "TAX", "IMP", &CPU::TAX, &CPU::IMP, 2, 1 };
+    _opcodeTable[0x8A] = InstructionData{ "TXA", "IMP", &CPU::TXA, &CPU::IMP, 2, 1 };
+    _opcodeTable[0xA8] = InstructionData{ "TAY", "IMP", &CPU::TAY, &CPU::IMP, 2, 1 };
+    _opcodeTable[0x98] = InstructionData{ "TYA", "IMP", &CPU::TYA, &CPU::IMP, 2, 1 };
 
-    // Illegal - SLO (03, 07, 0F, 13, 17, 1B, 1F)
-    _opcodeTable[0x03] = InstructionData{ "SLO_IndirectX", &CPU::SLO, &CPU::INDX, 8, 2 };
-    _opcodeTable[0x07] = InstructionData{ "SLO_ZeroPage", &CPU::SLO, &CPU::ZPG, 5, 2 };
-    _opcodeTable[0x0F] = InstructionData{ "SLO_Absolute", &CPU::SLO, &CPU::ABS, 6, 3 };
-    _opcodeTable[0x13] = InstructionData{ "SLO_IndirectY", &CPU::SLO, &CPU::INDY, 8, 2, false };
-    _opcodeTable[0x17] = InstructionData{ "SLO_ZeroPageX", &CPU::SLO, &CPU::ZPGX, 6, 2 };
-    _opcodeTable[0x1B] = InstructionData{ "SLO_AbsoluteY", &CPU::SLO, &CPU::ABSY, 7, 3, false };
-    _opcodeTable[0x1F] = InstructionData{ "SLO_AbsoluteX", &CPU::SLO, &CPU::ABSX, 7, 3, false };
+    /*
+    ################################
+    ||       Illegal Opcodes      ||
+    ################################
+    */
 
-    // Illegal - JAM (02, 12, 22, 32, 45, 52, 62, 72, 92, B2, D2, F2)
-    _opcodeTable[0x02] = InstructionData{ "JAM_Implied", &CPU::JAM, &CPU::IMP, 11, 1 };
-    _opcodeTable[0x12] = InstructionData{ "JAM_Implied", &CPU::JAM, &CPU::IMP, 11, 1 };
-    _opcodeTable[0x22] = InstructionData{ "JAM_Implied", &CPU::JAM, &CPU::IMP, 11, 1 };
-    _opcodeTable[0x32] = InstructionData{ "JAM_Implied", &CPU::JAM, &CPU::IMP, 11, 1 };
-    _opcodeTable[0x42] = InstructionData{ "JAM_Implied", &CPU::JAM, &CPU::IMP, 11, 1 };
-    _opcodeTable[0x52] = InstructionData{ "JAM_Implied", &CPU::JAM, &CPU::IMP, 11, 1 };
-    _opcodeTable[0x62] = InstructionData{ "JAM_Implied", &CPU::JAM, &CPU::IMP, 11, 1 };
-    _opcodeTable[0x72] = InstructionData{ "JAM_Implied", &CPU::JAM, &CPU::IMP, 11, 1 };
-    _opcodeTable[0x92] = InstructionData{ "JAM_Implied", &CPU::JAM, &CPU::IMP, 11, 1 };
-    _opcodeTable[0xB2] = InstructionData{ "JAM_Implied", &CPU::JAM, &CPU::IMP, 11, 1 };
-    _opcodeTable[0xD2] = InstructionData{ "JAM_Implied", &CPU::JAM, &CPU::IMP, 11, 1 };
-    _opcodeTable[0xF2] = InstructionData{ "JAM_Implied", &CPU::JAM, &CPU::IMP, 11, 1 };
+    // Jams (does nothing)
+    _opcodeTable[0x02] = InstructionData{ "*JAM", "IMP", &CPU::JAM, &CPU::IMP, 11, 1 };
+    _opcodeTable[0x12] = InstructionData{ "*JAM", "IMP", &CPU::JAM, &CPU::IMP, 11, 1 };
+    _opcodeTable[0x22] = InstructionData{ "*JAM", "IMP", &CPU::JAM, &CPU::IMP, 11, 1 };
+    _opcodeTable[0x32] = InstructionData{ "*JAM", "IMP", &CPU::JAM, &CPU::IMP, 11, 1 };
+    _opcodeTable[0x42] = InstructionData{ "*JAM", "IMP", &CPU::JAM, &CPU::IMP, 11, 1 };
+    _opcodeTable[0x52] = InstructionData{ "*JAM", "IMP", &CPU::JAM, &CPU::IMP, 11, 1 };
+    _opcodeTable[0x62] = InstructionData{ "*JAM", "IMP", &CPU::JAM, &CPU::IMP, 11, 1 };
+    _opcodeTable[0x72] = InstructionData{ "*JAM", "IMP", &CPU::JAM, &CPU::IMP, 11, 1 };
+    _opcodeTable[0x92] = InstructionData{ "*JAM", "IMP", &CPU::JAM, &CPU::IMP, 11, 1 };
+    _opcodeTable[0xB2] = InstructionData{ "*JAM", "IMP", &CPU::JAM, &CPU::IMP, 11, 1 };
+    _opcodeTable[0xD2] = InstructionData{ "*JAM", "IMP", &CPU::JAM, &CPU::IMP, 11, 1 };
+    _opcodeTable[0xF2] = InstructionData{ "*JAM", "IMP", &CPU::JAM, &CPU::IMP, 11, 1 };
 
-    // Illegal - SAX (87, 97, 8F, 83)
-    _opcodeTable[0x87] = InstructionData{ "SAX_ZeroPage", &CPU::SAX, &CPU::ZPG, 3, 2 };
-    _opcodeTable[0x97] = InstructionData{ "SAX_ZeroPageY", &CPU::SAX, &CPU::ZPGY, 4, 2 };
-    _opcodeTable[0x8F] = InstructionData{ "SAX_Absolute", &CPU::SAX, &CPU::ABS, 4, 3 };
-    _opcodeTable[0x83] = InstructionData{ "SAX_IndirectX", &CPU::SAX, &CPU::INDX, 6, 2 };
+    // NOP Implied
+    _opcodeTable[0x1A] = InstructionData{ "*NOP", "IMP", &CPU::NOP, &CPU::IMP, 2, 1 };
+    _opcodeTable[0x3A] = InstructionData{ "*NOP", "IMP", &CPU::NOP, &CPU::IMP, 2, 1 };
+    _opcodeTable[0x5A] = InstructionData{ "*NOP", "IMP", &CPU::NOP, &CPU::IMP, 2, 1 };
+    _opcodeTable[0x7A] = InstructionData{ "*NOP", "IMP", &CPU::NOP, &CPU::IMP, 2, 1 };
+    _opcodeTable[0xDA] = InstructionData{ "*NOP", "IMP", &CPU::NOP, &CPU::IMP, 2, 1 };
+    _opcodeTable[0xFA] = InstructionData{ "*NOP", "IMP", &CPU::NOP, &CPU::IMP, 2, 1 };
 
-    // Illegal - LXA (AB)
-    _opcodeTable[0xAB] = InstructionData{ "LXA_Immediate", &CPU::LXA, &CPU::IMM, 2, 2 };
+    // NOP Immediate
+    _opcodeTable[0x80] = InstructionData{ "*NOP", "IMM", &CPU::NOP2, &CPU::IMM, 2, 2 };
+    _opcodeTable[0x82] = InstructionData{ "*NOP", "IMM", &CPU::NOP2, &CPU::IMM, 2, 2 };
+    _opcodeTable[0x89] = InstructionData{ "*NOP", "IMM", &CPU::NOP2, &CPU::IMM, 2, 2 };
+    _opcodeTable[0xC2] = InstructionData{ "*NOP", "IMM", &CPU::NOP2, &CPU::IMM, 2, 2 };
+    _opcodeTable[0xE2] = InstructionData{ "*NOP", "IMM", &CPU::NOP2, &CPU::IMM, 2, 2 };
 
-    // Illegal - LAX (A7, B7, AF, BF, A3, B3)
-    _opcodeTable[0xA7] = InstructionData{ "LAX_ZeroPage", &CPU::LAX, &CPU::ZPG, 3, 2 };
-    _opcodeTable[0xB7] = InstructionData{ "LAX_ZeroPageY", &CPU::LAX, &CPU::ZPGY, 4, 2 };
-    _opcodeTable[0xAF] = InstructionData{ "LAX_Absolute", &CPU::LAX, &CPU::ABS, 4, 3 };
-    _opcodeTable[0xBF] = InstructionData{ "LAX_AbsoluteY", &CPU::LAX, &CPU::ABSY, 4, 3 };
-    _opcodeTable[0xA3] = InstructionData{ "LAX_IndirectX", &CPU::LAX, &CPU::INDX, 6, 2 };
-    _opcodeTable[0xB3] = InstructionData{ "LAX_IndirectY", &CPU::LAX, &CPU::INDY, 5, 2 };
+    // NOP Zero Page
+    _opcodeTable[0x04] = InstructionData{ "*NOP", "ZPG", &CPU::NOP2, &CPU::ZPG, 3, 2 };
+    _opcodeTable[0x44] = InstructionData{ "*NOP", "ZPG", &CPU::NOP2, &CPU::ZPG, 3, 2 };
+    _opcodeTable[0x64] = InstructionData{ "*NOP", "ZPG", &CPU::NOP2, &CPU::ZPG, 3, 2 };
 
-    // Illegal Opcode - ARR
-    _opcodeTable[0x6B] = InstructionData{ "ARR_Immediate", &CPU::ARR, &CPU::IMM, 2, 2 };
+    // NOP Zero Page X
+    _opcodeTable[0x14] = InstructionData{ "*NOP", "ZPGX", &CPU::NOP2, &CPU::ZPGX, 4, 2 };
+    _opcodeTable[0x34] = InstructionData{ "*NOP", "ZPGX", &CPU::NOP2, &CPU::ZPGX, 4, 2 };
+    _opcodeTable[0x54] = InstructionData{ "*NOP", "ZPGX", &CPU::NOP2, &CPU::ZPGX, 4, 2 };
+    _opcodeTable[0x74] = InstructionData{ "*NOP", "ZPGX", &CPU::NOP2, &CPU::ZPGX, 4, 2 };
+    _opcodeTable[0xD4] = InstructionData{ "*NOP", "ZPGX", &CPU::NOP2, &CPU::ZPGX, 4, 2 };
+    _opcodeTable[0xF4] = InstructionData{ "*NOP", "ZPGX", &CPU::NOP2, &CPU::ZPGX, 4, 2 };
 
-    // Illegal Opcode - ALR
-    _opcodeTable[0x4B] = InstructionData{ "ALR_Immediate", &CPU::ALR, &CPU::IMM, 2, 2 };
+    // NOP Absolute
+    _opcodeTable[0x0C] = InstructionData{ "*NOP", "ABS", &CPU::NOP2, &CPU::ABS, 4, 3 };
+    _opcodeTable[0x1C] = InstructionData{ "*NOP", "ABSX", &CPU::NOP2, &CPU::ABSX, 4, 3 };
+    _opcodeTable[0x3C] = InstructionData{ "*NOP", "ABSX", &CPU::NOP2, &CPU::ABSX, 4, 3 };
+    _opcodeTable[0x5C] = InstructionData{ "*NOP", "ABSX", &CPU::NOP2, &CPU::ABSX, 4, 3 };
+    _opcodeTable[0x7C] = InstructionData{ "*NOP", "ABSX", &CPU::NOP2, &CPU::ABSX, 4, 3 };
+    _opcodeTable[0xDC] = InstructionData{ "*NOP", "ABSX", &CPU::NOP2, &CPU::ABSX, 4, 3 };
+    _opcodeTable[0xFC] = InstructionData{ "*NOP", "ABSX", &CPU::NOP2, &CPU::ABSX, 4, 3 };
 
-    // Illegal Opcode - RRA
-    _opcodeTable[0x67] = InstructionData{ "RRA_ZeroPage", &CPU::RRA, &CPU::ZPG, 5, 2 };
-    _opcodeTable[0x77] = InstructionData{ "RRA_ZeroPageX", &CPU::RRA, &CPU::ZPGX, 6, 2 };
-    _opcodeTable[0x6F] = InstructionData{ "RRA_Absolute", &CPU::RRA, &CPU::ABS, 6, 3 };
-    _opcodeTable[0x7F] = InstructionData{ "RRA_AbsoluteX", &CPU::RRA, &CPU::ABSX, 7, 3, false };
-    _opcodeTable[0x7B] = InstructionData{ "RRA_AbsoluteY", &CPU::RRA, &CPU::ABSY, 7, 3, false };
-    _opcodeTable[0x63] = InstructionData{ "RRA_IndirectX", &CPU::RRA, &CPU::INDX, 8, 2, false };
-    _opcodeTable[0x73] = InstructionData{ "RRA_IndirectY", &CPU::RRA, &CPU::INDY, 8, 2, false };
+    // SLO (03, 07, 0F, 13, 17, 1B, 1F)
+    _opcodeTable[0x07] = InstructionData{ "*SLO", "ZPG", &CPU::SLO, &CPU::ZPG, 5, 2 };
+    _opcodeTable[0x17] = InstructionData{ "*SLO", "ZPGX", &CPU::SLO, &CPU::ZPGX, 6, 2 };
+    _opcodeTable[0x0F] = InstructionData{ "*SLO", "ABS", &CPU::SLO, &CPU::ABS, 6, 3 };
+    _opcodeTable[0x1F] = InstructionData{ "*SLO", "ABSX", &CPU::SLO, &CPU::ABSX, 7, 3, false, true };
+    _opcodeTable[0x1B] = InstructionData{ "*SLO", "ABSY", &CPU::SLO, &CPU::ABSY, 7, 3, false, true };
+    _opcodeTable[0x03] = InstructionData{ "*SLO", "INDX", &CPU::SLO, &CPU::INDX, 8, 2 };
+    _opcodeTable[0x13] = InstructionData{ "*SLO", "INDY", &CPU::SLO, &CPU::INDY, 8, 2, false, true };
 
-    // Illegal Opcode - SRE
-    _opcodeTable[0x47] = InstructionData{ "SRE_ZeroPage", &CPU::SRE, &CPU::ZPG, 5, 2 };
-    _opcodeTable[0x57] = InstructionData{ "SRE_ZeroPageX", &CPU::SRE, &CPU::ZPGX, 6, 2 };
-    _opcodeTable[0x4F] = InstructionData{ "SRE_Absolute", &CPU::SRE, &CPU::ABS, 6, 3 };
-    _opcodeTable[0x5F] = InstructionData{ "SRE_AbsoluteX", &CPU::SRE, &CPU::ABSX, 7, 3, false };
-    _opcodeTable[0x5B] = InstructionData{ "SRE_AbsoluteY", &CPU::SRE, &CPU::ABSY, 7, 3, false };
-    _opcodeTable[0x43] = InstructionData{ "SRE_IndirectX", &CPU::SRE, &CPU::INDX, 8, 2, false };
-    _opcodeTable[0x53] = InstructionData{ "SRE_IndirectY", &CPU::SRE, &CPU::INDY, 8, 2, false };
+    // SAX (87, 97, 8F, 83)
+    _opcodeTable[0x87] = InstructionData{ "*SAX", "ZPG", &CPU::SAX, &CPU::ZPG, 3, 2 };
+    _opcodeTable[0x97] = InstructionData{ "*SAX", "ZPGY", &CPU::SAX, &CPU::ZPGY, 4, 2, true, true };
+    _opcodeTable[0x8F] = InstructionData{ "*SAX", "ABS", &CPU::SAX, &CPU::ABS, 4, 3 };
+    _opcodeTable[0x83] = InstructionData{ "*SAX", "INDX", &CPU::SAX, &CPU::INDX, 6, 2 };
 
-    // Illegal Opcode - RLA
-    _opcodeTable[0x27] = InstructionData{ "RLA_ZeroPage", &CPU::RLA, &CPU::ZPG, 5, 2 };
-    _opcodeTable[0x37] = InstructionData{ "RLA_ZeroPageX", &CPU::RLA, &CPU::ZPGX, 6, 2 };
-    _opcodeTable[0x2F] = InstructionData{ "RLA_Absolute", &CPU::RLA, &CPU::ABS, 6, 3 };
-    _opcodeTable[0x3F] = InstructionData{ "RLA_AbsoluteX", &CPU::RLA, &CPU::ABSX, 7, 3, false };
-    _opcodeTable[0x3B] = InstructionData{ "RLA_AbsoluteY", &CPU::RLA, &CPU::ABSY, 7, 3, false };
-    _opcodeTable[0x23] = InstructionData{ "RLA_IndirectX", &CPU::RLA, &CPU::INDX, 8, 2 };
-    _opcodeTable[0x33] = InstructionData{ "RLA_IndirectY", &CPU::RLA, &CPU::INDY, 8, 2, false };
+    // LXA (AB)
+    _opcodeTable[0xAB] = InstructionData{ "*LXA", "IMM", &CPU::LXA, &CPU::IMM, 2, 2 };
 
-    // Illegal Opcode - DCP
-    _opcodeTable[0xC7] = InstructionData{ "DCP_ZeroPage", &CPU::DCP, &CPU::ZPG, 5, 2 };
-    _opcodeTable[0xD7] = InstructionData{ "DCP_ZeroPageX", &CPU::DCP, &CPU::ZPGX, 6, 2 };
-    _opcodeTable[0xCF] = InstructionData{ "DCP_Absolute", &CPU::DCP, &CPU::ABS, 6, 3 };
-    _opcodeTable[0xDF] = InstructionData{ "DCP_AbsoluteX", &CPU::DCP, &CPU::ABSX, 7, 3, false };
-    _opcodeTable[0xDB] = InstructionData{ "DCP_AbsoluteY", &CPU::DCP, &CPU::ABSY, 7, 3, false };
-    _opcodeTable[0xC3] = InstructionData{ "DCP_IndirectX", &CPU::DCP, &CPU::INDX, 8, 2 };
-    _opcodeTable[0xD3] = InstructionData{ "DCP_IndirectY", &CPU::DCP, &CPU::INDY, 8, 2, false };
+    // LAX (A7, B7, AF, BF, A3, B3)
+    _opcodeTable[0xA7] = InstructionData{ "*LAX", "ZPG", &CPU::LAX, &CPU::ZPG, 3, 2 };
+    _opcodeTable[0xB7] = InstructionData{ "*LAX", "ZPGY", &CPU::LAX, &CPU::ZPGY, 4, 2, true, true };
+    _opcodeTable[0xAF] = InstructionData{ "*LAX", "ABS", &CPU::LAX, &CPU::ABS, 4, 3 };
+    _opcodeTable[0xBF] = InstructionData{ "*LAX", "ABSY", &CPU::LAX, &CPU::ABSY, 4, 3 };
+    _opcodeTable[0xA3] = InstructionData{ "*LAX", "INDX", &CPU::LAX, &CPU::INDX, 6, 2 };
+    _opcodeTable[0xB3] = InstructionData{ "*LAX", "INDY", &CPU::LAX, &CPU::INDY, 5, 2 };
 
-    // Illegal Opcode - ISC
-    _opcodeTable[0xE7] = InstructionData{ "ISC_ZeroPage", &CPU::ISC, &CPU::ZPG, 5, 2 };
-    _opcodeTable[0xF7] = InstructionData{ "ISC_ZeroPageX", &CPU::ISC, &CPU::ZPGX, 6, 2 };
-    _opcodeTable[0xEF] = InstructionData{ "ISC_Absolute", &CPU::ISC, &CPU::ABS, 6, 3 };
-    _opcodeTable[0xFF] = InstructionData{ "ISC_AbsoluteX", &CPU::ISC, &CPU::ABSX, 7, 3, false };
-    _opcodeTable[0xFB] = InstructionData{ "ISC_AbsoluteY", &CPU::ISC, &CPU::ABSY, 7, 3, false };
-    _opcodeTable[0xE3] = InstructionData{ "ISC_IndirectX", &CPU::ISC, &CPU::INDX, 8, 2 };
-    _opcodeTable[0xF3] = InstructionData{ "ISC_IndirectY", &CPU::ISC, &CPU::INDY, 8, 2, false };
+    // ARR
+    _opcodeTable[0x6B] = InstructionData{ "*ARR", "IMM", &CPU::ARR, &CPU::IMM, 2, 2 };
 
-    // Illegal Opcode - ANC
-    _opcodeTable[0x0B] = InstructionData{ "ANC_Immediate_1", &CPU::ANC, &CPU::IMM, 2, 2 };
-    _opcodeTable[0x2B] = InstructionData{ "ANC_Immediate_2", &CPU::ANC, &CPU::IMM, 2, 2 };
+    // ALR
+    _opcodeTable[0x4B] = InstructionData{ "*ALR", "IMM", &CPU::ALR, &CPU::IMM, 2, 2 };
+
+    // RRA
+    _opcodeTable[0x67] = InstructionData{ "*RRA", "ZPG", &CPU::RRA, &CPU::ZPG, 5, 2 };
+    _opcodeTable[0x77] = InstructionData{ "*RRA", "ZPGX", &CPU::RRA, &CPU::ZPGX, 6, 2 };
+    _opcodeTable[0x6F] = InstructionData{ "*RRA", "ABS", &CPU::RRA, &CPU::ABS, 6, 3 };
+    _opcodeTable[0x7F] = InstructionData{ "*RRA", "ABSX", &CPU::RRA, &CPU::ABSX, 7, 3, false, true };
+    _opcodeTable[0x7B] = InstructionData{ "*RRA", "ABSY", &CPU::RRA, &CPU::ABSY, 7, 3, false, true };
+    _opcodeTable[0x63] = InstructionData{ "*RRA", "INDX", &CPU::RRA, &CPU::INDX, 8, 2 };
+    _opcodeTable[0x73] = InstructionData{ "*RRA", "INDY", &CPU::RRA, &CPU::INDY, 8, 2, false, true };
+
+    // SRE
+    _opcodeTable[0x47] = InstructionData{ "*SRE", "ZPG", &CPU::SRE, &CPU::ZPG, 5, 2 };
+    _opcodeTable[0x57] = InstructionData{ "*SRE", "ZPGX", &CPU::SRE, &CPU::ZPGX, 6, 2 };
+    _opcodeTable[0x4F] = InstructionData{ "*SRE", "ABS", &CPU::SRE, &CPU::ABS, 6, 3 };
+    _opcodeTable[0x5F] = InstructionData{ "*SRE", "ABSX", &CPU::SRE, &CPU::ABSX, 7, 3, false, true };
+    _opcodeTable[0x5B] = InstructionData{ "*SRE", "ABSY", &CPU::SRE, &CPU::ABSY, 7, 3, false, true };
+    _opcodeTable[0x43] = InstructionData{ "*SRE", "INDX", &CPU::SRE, &CPU::INDX, 8, 2 };
+    _opcodeTable[0x53] = InstructionData{ "*SRE", "INDY", &CPU::SRE, &CPU::INDY, 8, 2, false, true };
+
+    // RLA
+    _opcodeTable[0x27] = InstructionData{ "*RLA", "ZPG", &CPU::RLA, &CPU::ZPG, 5, 2 };
+    _opcodeTable[0x37] = InstructionData{ "*RLA", "ZPGX", &CPU::RLA, &CPU::ZPGX, 6, 2 };
+    _opcodeTable[0x2F] = InstructionData{ "*RLA", "ABS", &CPU::RLA, &CPU::ABS, 6, 3 };
+    _opcodeTable[0x3F] = InstructionData{ "*RLA", "ABSX", &CPU::RLA, &CPU::ABSX, 7, 3, false, true };
+    _opcodeTable[0x3B] = InstructionData{ "*RLA", "ABSY", &CPU::RLA, &CPU::ABSY, 7, 3, false, true };
+    _opcodeTable[0x23] = InstructionData{ "*RLA", "INDX", &CPU::RLA, &CPU::INDX, 8, 2 };
+    _opcodeTable[0x33] = InstructionData{ "*RLA", "INDY", &CPU::RLA, &CPU::INDY, 8, 2, false, true };
+
+    // DCP
+    _opcodeTable[0xC7] = InstructionData{ "*DCP", "ZPG", &CPU::DCP, &CPU::ZPG, 5, 2 };
+    _opcodeTable[0xD7] = InstructionData{ "*DCP", "ZPGX", &CPU::DCP, &CPU::ZPGX, 6, 2 };
+    _opcodeTable[0xCF] = InstructionData{ "*DCP", "ABS", &CPU::DCP, &CPU::ABS, 6, 3 };
+    _opcodeTable[0xDF] = InstructionData{ "*DCP", "ABSX", &CPU::DCP, &CPU::ABSX, 7, 3, false, true };
+    _opcodeTable[0xDB] = InstructionData{ "*DCP", "ABSY", &CPU::DCP, &CPU::ABSY, 7, 3, false, true };
+    _opcodeTable[0xC3] = InstructionData{ "*DCP", "INDX", &CPU::DCP, &CPU::INDX, 8, 2 };
+    _opcodeTable[0xD3] = InstructionData{ "*DCP", "INDY", &CPU::DCP, &CPU::INDY, 8, 2, false, true };
+
+    // ISC
+    _opcodeTable[0xE7] = InstructionData{ "*ISC", "ZPG", &CPU::ISC, &CPU::ZPG, 5, 2 };
+    _opcodeTable[0xF7] = InstructionData{ "*ISC", "ZPGX", &CPU::ISC, &CPU::ZPGX, 6, 2 };
+    _opcodeTable[0xEF] = InstructionData{ "*ISC", "ABS", &CPU::ISC, &CPU::ABS, 6, 3 };
+    _opcodeTable[0xFF] = InstructionData{ "*ISC", "ABSX", &CPU::ISC, &CPU::ABSX, 7, 3, false, true };
+    _opcodeTable[0xFB] = InstructionData{ "*ISC", "ABSY", &CPU::ISC, &CPU::ABSY, 7, 3, false, true };
+    _opcodeTable[0xE3] = InstructionData{ "*ISC", "INDX", &CPU::ISC, &CPU::INDX, 8, 2 };
+    _opcodeTable[0xF3] = InstructionData{ "*ISC", "INDY", &CPU::ISC, &CPU::INDY, 8, 2, false, true };
+
+    // SBC2
+    _opcodeTable[0xEB] = InstructionData{ "*SBC", "IMM", &CPU::SBC, &CPU::IMM, 2, 2 };
+
+    // ANC
+    _opcodeTable[0x0B] = InstructionData{ "*ANC", "IMM", &CPU::ANC, &CPU::IMM, 2, 2 };
+    _opcodeTable[0x2B] = InstructionData{ "*ANC", "IMM", &CPU::ANC, &CPU::IMM, 2, 2 };
+
+    // SBX
+    _opcodeTable[0xCB] = InstructionData{ "*SBX", "IMM", &CPU::SBX, &CPU::IMM, 2, 2 };
+
+    /*
+    ################################
+    ||         Validation         ||
+    ################################
+    */
+    // Validate Opcode names and address mode strings
+    for ( int i = 0; i < 256; i++ )
+    {
+        string const name = _opcodeTable[i].name;
+        // if no name, skip, it's an empty entry
+        if ( name.empty() )
+        {
+            continue;
+        }
+        string const addr_mode = _opcodeTable[i].addr_mode;
+        if ( !utils::isValidOpcodeName( name ) )
+        {
+            string output = "Invalid opcode name: " + name;
+            output += " for opcode: " + utils::toHex( i, 2 );
+            output += '\n';
+            output += "Valid names: \n" + utils::getAvailableOpcodeNames();
+            throw std::runtime_error( output );
+        }
+        if ( !utils::isValidAddrModeStr( addr_mode ) )
+        {
+            string output = "Invalid address mode string: " + addr_mode;
+            output += " for opcode: " + utils::toHex( i, 2 );
+            output += '\n';
+            output += "Valid address mode strings: \n" + utils::getAvailableAddrModes();
+            throw std::runtime_error( output );
+        };
+    }
 };
 
-// Getters
+/*
+################################################
+||                                            ||
+||                   Getters                  ||
+||                                            ||
+################################################
+*/
 [[nodiscard]] u8  CPU::GetAccumulator() const { return _a; }
 [[nodiscard]] u8  CPU::GetXRegister() const { return _x; }
 [[nodiscard]] u8  CPU::GetYRegister() const { return _y; }
@@ -355,7 +411,13 @@ CPU::CPU( Bus *bus ) : _bus( bus ), _opcodeTable{}
 [[nodiscard]] u8  CPU::GetStackPointer() const { return _s; }
 [[nodiscard]] u64 CPU::GetCycles() const { return _cycles; }
 
-// Setters
+/*
+################################################
+||                                            ||
+||                   Setters                  ||
+||                                            ||
+################################################
+*/
 void CPU::SetAccumulator( u8 value ) { _a = value; }
 void CPU::SetXRegister( u8 value ) { _x = value; }
 void CPU::SetYRegister( u8 value ) { _y = value; }
@@ -365,84 +427,16 @@ void CPU::SetStackPointer( u8 value ) { _s = value; }
 void CPU::SetCycles( u64 value ) { _cycles = value; }
 
 /*
-################################################################
-||                                                            ||
-||                        CPU Methods                         ||
-||                                                            ||
-################################################################
+################################################
+||                                            ||
+||                Debug Methods               ||
+||                                            ||
+################################################
 */
+[[nodiscard]] std::string CPU::GetTrace() const { return _trace; }
 
-// Pass off reads and writes to the bus
-auto CPU::Read( u16 address ) const -> u8 { return _bus->Read( address ); }
-void CPU::Write( u16 address, u8 data ) const { _bus->Write( address, data ); }
-
-u8 CPU::Fetch()
-{
-    // Read the current PC location and increment it
-    return Read( _pc++ );
-}
-
-/**
- * @brief Executes a single CPU cycle.
- *
- * This function fetches the next opcode from memory, decodes it using the opcode table,
- * and executes that instruction. It also adds the number of cycles the instruction
- * takes to the total cycle count.
- *
- * If the opcode is invalid, an error message is printed to stderr.
- */
-void CPU::Tick()
-{
-    // debug, print the instruction
-    // std::cout << LogLineAtPC() << '\n';
-
-    // Fetch the next opcode and increment the program counter
-    u8 const opcode = Fetch();
-
-    // Decode the opcode
-    auto const &instruction = _opcodeTable[opcode];
-    auto        instruction_handler = instruction.instructionMethod;
-    auto        addressing_mode_handler = instruction.addressingModeMethod;
-
-    if ( instruction_handler != nullptr && addressing_mode_handler != nullptr )
-    {
-        // Set the page cross penalty for the current instruction
-        // Used in addressing modes: ABSX, ABSY, INDY
-        _currentPageCrossPenalty = instruction.pageCrossPenalty;
-
-        // Calculate the address using the addressing mode
-        u16 const address = ( this->*addressing_mode_handler )();
-
-        // Execute the instruction fetched from the opcode table
-        ( this->*instruction_handler )( address );
-
-        // Add the number of cycles the instruction takes
-        _cycles += instruction.cycles;
-
-        // Set the _imp flag to false
-        _imp = false;
-    }
-    else
-    {
-        // Houston, we have a problem. No opcode was found.
-        std::cerr << "Bad opcode: " << std::hex << static_cast<int>( opcode ) << '\n';
-    }
-}
-
-void CPU::Reset()
-{
-    _a = 0x00;
-    _x = 0x00;
-    _y = 0x00;
-    _s = 0xFD;
-    _p = 0x00 | Unused;
-    _cycles = 0;
-
-    // The program counter is usually read from the reset vector of a game, which is
-    // located at 0xFFFC and 0xFFFD. If no cartridge, we'll assume these values are
-    // initialized to 0x00
-    _pc = Read( 0xFFFD ) << 8 | Read( 0xFFFC );
-}
+void CPU::EnableTracelog() { _trace_enabled = true; }
+void CPU::DisableTracelog() { _trace_enabled = false; }
 
 std::string CPU::LogLineAtPC( bool verbose ) // NOLINT
 {
@@ -452,21 +446,8 @@ std::string CPU::LogLineAtPC( bool verbose ) // NOLINT
      */
     std::string output;
 
-    // Fetch the instruction name and address mode from the opcode table
-    std::string const &name_addrmode = _opcodeTable[Read( _pc )].name;
-    if ( name_addrmode.empty() )
-    {
-        std::cerr << "Attempted to grab from a non existing table entry at PC: " << utils::toHex( _pc, 4 )
-                  << '\n';
-        std::cerr << "Opcode: " << utils::toHex( Read( _pc ), 2 ) << '\n';
-        // This is only used for debugging, so we can throw an exception
-        throw std::runtime_error( "Invalid opcode" );
-    }
-
-    // Split name and addressing mode
-    size_t const      split_pos = name_addrmode.find( '_' );
-    std::string       name = name_addrmode.substr( 0, split_pos );
-    std::string const addr_mode = name_addrmode.substr( split_pos + 1 );
+    std::string name = _opcodeTable[Read( _pc )].name;
+    std::string addr_mode = _opcodeTable[Read( _pc )].addr_mode;
 
     // Program counter address
     // i.e. FFFF
@@ -490,53 +471,54 @@ std::string CPU::LogLineAtPC( bool verbose ) // NOLINT
     ( name[0] == '*' ) ? output += "*" + name.substr( 1 ) + " " : output += name + " ";
 
     // Addressing mode and operand
+
     std::string assembly_str;
     u8          value = 0x00;
     u8          low = 0x00;
     u8          high = 0x00;
-    if ( addr_mode == "Implied" )
+    if ( addr_mode == "IMP" )
     {
         // Nothing to prefix
     }
-    else if ( addr_mode == "Immediate" )
+    else if ( addr_mode == "IMM" )
     {
         value = Read( _pc + 1 );
         assembly_str += "#$" + utils::toHex( value, 2 );
     }
-    else if ( addr_mode == "ZeroPage" || addr_mode == "ZeroPageX" || addr_mode == "ZeroPageY" )
+    else if ( addr_mode == "ZPG" || addr_mode == "ZPGX" || addr_mode == "ZPGY" )
     {
         value = Read( _pc + 1 );
         assembly_str += "$" + utils::toHex( value, 2 );
 
-        ( addr_mode == "ZeroPageX" )   ? assembly_str += ", X"
-        : ( addr_mode == "ZeroPageY" ) ? assembly_str += ", Y"
-                                       : assembly_str += "";
+        ( addr_mode == "ZPGX" )   ? assembly_str += ", X"
+        : ( addr_mode == "ZPGY" ) ? assembly_str += ", Y"
+                                  : assembly_str += "";
     }
-    else if ( addr_mode == "Absolute" || addr_mode == "AbsoluteX" || addr_mode == "AbsoluteY" )
+    else if ( addr_mode == "ABS" || addr_mode == "ABSX" || addr_mode == "ABSY" )
     {
         low = Read( _pc + 1 );
         high = Read( _pc + 2 );
         u16 const address = ( high << 8 ) | low;
 
         assembly_str += "$" + utils::toHex( address, 4 );
-        ( addr_mode == "AbsoluteX" )   ? assembly_str += ", X"
-        : ( addr_mode == "AbsoluteY" ) ? assembly_str += ", Y"
-                                       : assembly_str += "";
+        ( addr_mode == "ABSX" )   ? assembly_str += ", X"
+        : ( addr_mode == "ABSY" ) ? assembly_str += ", Y"
+                                  : assembly_str += "";
     }
-    else if ( addr_mode == "Indirect" )
+    else if ( addr_mode == "IND" )
     {
         low = Read( _pc + 1 );
         high = Read( _pc + 2 );
         u16 const address = ( high << 8 ) | low;
         assembly_str += "($" + utils::toHex( address, 4 ) + ")";
     }
-    else if ( addr_mode == "IndirectX" || addr_mode == "IndirectY" )
+    else if ( addr_mode == "INDX" || addr_mode == "INDY" )
     {
         value = Read( _pc + 1 );
-        ( addr_mode == "IndirectX" ) ? assembly_str += "($" + utils::toHex( value, 2 ) + ", X)"
-                                     : assembly_str += "($" + utils::toHex( value, 2 ) + "), Y";
+        ( addr_mode == "INDX" ) ? assembly_str += "($" + utils::toHex( value, 2 ) + ", X)"
+                                : assembly_str += "($" + utils::toHex( value, 2 ) + "), Y";
     }
-    else if ( addr_mode == "Relative" )
+    else if ( addr_mode == "REL" )
     {
         value = Read( _pc + 1 );
         s8 const  offset = static_cast<s8>( value );
@@ -549,8 +531,8 @@ std::string CPU::LogLineAtPC( bool verbose ) // NOLINT
         // Houston.. yet again
         throw std::runtime_error( "Unknown addressing mode: " + addr_mode );
     }
-    // Pad the assembly string with spaces, for fixed length
 
+    // Pad the assembly string with spaces, for fixed length
     output += assembly_str + std::string( 15 - assembly_str.size(), ' ' );
 
     // Add more log info
@@ -571,7 +553,7 @@ std::string CPU::LogLineAtPC( bool verbose ) // NOLINT
         status_str += "p: " + utils::toHex( _p, 2 ) + "  ";
 
         std::string status_flags = "NV-BDIZC";
-        std::string status_flags_lower = "nv-bdizc";
+        std::string status_flags_lower = "nv--dizc";
         std::string status_flags_str;
         for ( int i = 7; i >= 0; i-- )
         {
@@ -582,12 +564,240 @@ std::string CPU::LogLineAtPC( bool verbose ) // NOLINT
         // Combine to the output string
         output += registers_str + status_str;
 
+        // Scanline num (V)
+        std::string scanline_str = std::to_string( _bus->ppu.GetScanline() );
+        // std::string scanline_str_adjusted = std::string( 4 - scanline_str.size(), ' ' );
+        output += "  V: " + scanline_str;
+
+        // PPU cycles (H), pad for 3 characters + space
+        u16 const   ppu_cycles = _bus->ppu.GetCycles();
+        std::string ppu_cycles_str = std::to_string( ppu_cycles );
+        ppu_cycles_str += std::string( 4 - ppu_cycles_str.size(), ' ' );
+        output += "  H: " + ppu_cycles_str; // PPU cycle
+
         // cycle count
         output += "  Cycle: " + std::to_string( _cycles );
     }
+
     return output;
 }
 
+/*
+################################################################
+||                                                            ||
+||                        CPU Methods                         ||
+||                                                            ||
+################################################################
+*/
+
+// Pass off reads and writes to the bus
+auto CPU::Read( u16 address ) const -> u8 { return _bus->Read( address ); }
+void CPU::Write( u16 address, u8 data ) const { _bus->Write( address, data ); }
+
+// Read with cycle spend
+auto CPU::ReadAndTick( u16 address ) -> u8
+{
+    if ( address == 0x2002 )
+    {
+        _bus->ppu.SetIsCpuReadingPpuStatus( true );
+    }
+    Tick();
+    u8 const data = Read( address );
+    return data;
+}
+
+// Write and spend a cycle
+auto CPU::WriteAndTick( u16 address, u8 data ) -> void
+{
+    Tick();
+
+    // Writing to PPUCTRL, PPUMASK, PPUSCROLL, and PPUADDR is ignored until after cycle ~29658
+    if ( !_bus->IsTestMode() &&
+         ( address == 0x2000 || address == 0x2001 || address == 0x2005 || address == 0x2006 ) )
+    {
+        if ( _cycles < 29658 )
+        {
+            return;
+        }
+    }
+    Write( address, data );
+}
+
+u8 CPU::Fetch()
+{
+
+    // Read the current PC location and increment it
+
+    u8 const opcode = ReadAndTick( _pc++ );
+    return opcode;
+}
+
+void CPU::Tick()
+{
+    // Increment the cycle count
+    _cycles++;
+    _bus->ppu.Tick();
+    _bus->ppu.Tick();
+
+    /*
+       Saves cpu state after 2 ppu cycles of the first cpu cycle.
+       Used for creating a trace log that matches Mesen. This is
+       a costly operation, so it's only used for debugging
+     */
+    if ( !_did_trace && _trace_enabled )
+    {
+        _pc--;
+        _trace = LogLineAtPC( true );
+        _pc++;
+        _did_trace = true;
+    }
+
+    _bus->ppu.Tick();
+}
+
+void CPU::Reset()
+{
+    _a = 0x00;
+    _x = 0x00;
+    _y = 0x00;
+    _s = 0xFD;
+    _p = 0x00 | Unused | InterruptDisable;
+
+    // The program counter is usually read from the reset vector of a game, which is
+    // located at 0xFFFC and 0xFFFD. If no cartridge, we'll assume 0x00 for both
+    _pc = Read( 0xFFFD ) << 8 | Read( 0xFFFC );
+
+    // Add 7 cycles
+    if ( !_bus->IsTestMode() )
+    {
+
+        for ( u8 i = 0; i < 7; i++ )
+        {
+            Tick();
+        }
+    }
+    else
+    {
+        _cycles = 0;
+    }
+}
+
+/**
+ * @brief Executes a single CPU cycle.
+ *
+ * This function fetches the next opcode from memory, decodes it using the opcode table,
+ * and executes that instruction. It also adds the number of cycles the instruction
+ * takes to the total cycle count.
+ *
+ * If the opcode is invalid, an error message is printed to stderr.
+ */
+
+void CPU::NMI()
+{
+    /* @details: Non-maskable Interrupt, called by the PPU during the VBlank period.
+     * It interrupts whatever the CPU is doing at its current cycle to go update the PPU.
+     * Uses 7 cycles, cannot be disabled.
+     */
+    // 1) Two dummy cycles (hardware reads the same PC twice, discarding the data)
+    Tick();
+    Tick();
+
+    // 2) Push PC high, then PC low
+    StackPush( ( _pc >> 8 ) & 0xFF );
+    StackPush( _pc & 0xFF );
+
+    // 3) Push status register with B=0; bit 5 (Unused) = 1
+    u8 pushed_status = ( _p & ~Break ) | Unused;
+    StackPush( pushed_status );
+
+    // 4) Fetch low byte of NMI vector ($FFFA)
+    u8 low = ReadAndTick( 0xFFFA );
+
+    // 5) Set I flag
+    SetFlags( InterruptDisable );
+
+    // 6) Fetch high byte of NMI vector ($FFFB)
+    u8 high = ReadAndTick( 0xFFFB );
+
+    // 7) Update PC
+    _pc = static_cast<u16>( high ) << 8 | low;
+}
+
+void CPU::IRQ()
+{
+    /* @brief: IRQ, can be called when interrupt disable is turned off.
+     * Uses 7 cycles
+     */
+    if ( ( _p & InterruptDisable ) != 0 )
+    {
+        return;
+    }
+    Tick();
+    Tick();
+    StackPush( ( _pc >> 8 ) & 0xFF );
+    StackPush( _pc & 0xFF );
+    u8 pushed_status = ( _p & ~Break ) | Unused;
+    StackPush( pushed_status );
+    u8 low = ReadAndTick( 0xFFFE );
+    SetFlags( InterruptDisable );
+    u8 high = ReadAndTick( 0xFFFF );
+    _pc = static_cast<u16>( high ) << 8 | low;
+}
+
+void CPU::DecodeExecute()
+{
+
+    /**
+     * @brief Decode and execute an instruction
+     *
+     * This function fetches the next opcode from memory, decodes it using the opcode table,
+     * and executes that instruction.
+     *
+     * If the opcode is invalid, an error message is printed to stderr.
+     */
+
+    _did_trace = false;
+
+    // Fetch the next opcode and increment the program counter
+    u8 const opcode = Fetch();
+
+    // Decode the opcode
+    auto const &instruction = _opcodeTable[opcode];
+    auto        instruction_handler = instruction.instructionMethod;
+    auto        addressing_mode_handler = instruction.addressingModeMethod;
+
+    if ( instruction_handler != nullptr && addressing_mode_handler != nullptr )
+    {
+        // Set the page cross penalty for the current instruction
+        // Used in addressing modes: ABSX, ABSY, INDY
+        _currentPageCrossPenalty = instruction.pageCrossPenalty;
+
+        // Write / modify instructions use a dummy read before writing, so
+        // we should set a flag for those
+        _is_write_modify = instruction.isWriteModify;
+
+        // Set current instr mnemonic globally
+        _instruction_name = instruction.name;
+
+        // Set current address mode string globally
+        _addr_mode = instruction.addr_mode;
+
+        // Calculate the address using the addressing mode
+        u16 const address = ( this->*addressing_mode_handler )();
+
+        // Execute the instruction fetched from the opcode table
+        ( this->*instruction_handler )( address );
+
+        // Reset flags
+        _is_write_modify = false;
+        _did_trace = false;
+    }
+    else
+    {
+        // Houston, we have a problem. No opcode was found.
+        std::cerr << "Bad opcode: " << std::hex << static_cast<int>( opcode ) << '\n';
+    }
+}
 /*
 ################################################################
 ||                                                            ||
@@ -602,7 +812,7 @@ auto CPU::IMP() -> u16
      * @brief Implicit addressing mode
      * This mode does not require an operand
      */
-    _imp = true;
+    Tick();
     return 0;
 }
 
@@ -623,7 +833,7 @@ auto CPU::ZPG() -> u16
      * Returns the address from the zero page (0x0000 - 0x00FF).
      * The value of the next byte is the address in the zero page.
      */
-    return Read( _pc++ ) & 0x00FF;
+    return ReadAndTick( _pc++ ) & 0x00FF;
 }
 
 auto CPU::ZPGX() -> u16
@@ -633,7 +843,10 @@ auto CPU::ZPGX() -> u16
      * Returns the address from the zero page (0x0000 - 0x00FF) + X register
      * The value of the next byte is the address in the zero page.
      */
-    return ( Read( _pc++ ) + _x ) & 0x00FF;
+    u8 const  zero_page_address = ReadAndTick( _pc++ );
+    u16 const final_address = ( zero_page_address + _x ) & 0x00FF;
+    Tick(); // Account for calculating the final address
+    return final_address;
 }
 
 auto CPU::ZPGY() -> u16
@@ -643,7 +856,13 @@ auto CPU::ZPGY() -> u16
      * Returns the address from the zero page (0x0000 - 0x00FF) + Y register
      * The value of the next byte is the address in the zero page.
      */
-    return ( Read( _pc++ ) + _y ) & 0x00FF;
+    u8 const zero_page_address = ( ReadAndTick( _pc++ ) + _y ) & 0x00FF;
+
+    if ( _is_write_modify )
+    {
+        Tick();
+    }
+    return zero_page_address;
 }
 
 auto CPU::ABS() -> u16
@@ -652,8 +871,8 @@ auto CPU::ABS() -> u16
      * @brief Absolute addressing mode
      * Constructs a 16-bit address from the next two bytes
      */
-    u16 const low = Read( _pc++ );
-    u16 const high = Read( _pc++ );
+    u16 const low = ReadAndTick( _pc++ );
+    u16 const high = ReadAndTick( _pc++ );
     return ( high << 8 ) | low;
 }
 
@@ -664,8 +883,8 @@ auto CPU::ABSX() -> u16
      * Constructs a 16-bit address from the next two bytes and adds the X register to the final
      * address
      */
-    u16 const low = Read( _pc++ );
-    u16 const high = Read( _pc++ );
+    u16 const low = ReadAndTick( _pc++ );
+    u16 const high = ReadAndTick( _pc++ );
     u16 const address = ( high << 8 ) | low;
     u16 const final_address = address + _x;
 
@@ -673,9 +892,14 @@ auto CPU::ABSX() -> u16
     // Instructions that should ignore this: ASL, ROL, LSR, ROR, STA, DEC, INC
     if ( _currentPageCrossPenalty && ( final_address & 0xFF00 ) != ( address & 0xFF00 ) )
     {
-        _cycles++;
+        Tick();
     }
 
+    if ( _is_write_modify )
+    {
+        // Dummy read, in preparation to overwrite the address
+        Tick();
+    }
     return final_address;
 }
 
@@ -686,8 +910,8 @@ auto CPU::ABSY() -> u16
      * Constructs a 16-bit address from the next two bytes and adds the Y register to the final
      * address
      */
-    u16 const low = Read( _pc++ );
-    u16 const high = Read( _pc++ );
+    u16 const low = ReadAndTick( _pc++ );
+    u16 const high = ReadAndTick( _pc++ );
     u16 const address = ( high << 8 ) | low;
     u16 const final_address = address + _y;
 
@@ -695,7 +919,12 @@ auto CPU::ABSY() -> u16
     // Instructions that should ignore this: STA
     if ( _currentPageCrossPenalty && ( final_address & 0xFF00 ) != ( address & 0xFF00 ) )
     {
-        _cycles++;
+        Tick();
+    }
+    if ( _is_write_modify )
+    {
+        // Dummy read, in preparation to overwrite the address
+        Tick();
     }
 
     return final_address;
@@ -711,11 +940,11 @@ auto CPU::IND() -> u16
      * There's a hardware bug that prevents the address from crossing a page boundary
      */
 
-    u16 const ptr_low = Read( _pc++ );
-    u16 const ptr_high = Read( _pc++ );
+    u16 const ptr_low = ReadAndTick( _pc++ );
+    u16 const ptr_high = ReadAndTick( _pc++ );
     u16 const ptr = ( ptr_high << 8 ) | ptr_low;
 
-    u8 const address_low = Read( ptr );
+    u8 const address_low = ReadAndTick( ptr );
     u8       address_high; // NOLINT
 
     // 6502 Bug: If the pointer address wraps around a page boundary (e.g. 0x01FF),
@@ -723,11 +952,11 @@ auto CPU::IND() -> u16
     // the same page (0x0100) instead of the start of the next page (0x0200).
     if ( ptr_low == 0xFF )
     {
-        address_high = Read( ptr & 0xFF00 );
+        address_high = ReadAndTick( ptr & 0xFF00 );
     }
     else
     {
-        address_high = Read( ptr + 1 );
+        address_high = ReadAndTick( ptr + 1 );
     }
 
     return ( address_high << 8 ) | address_low;
@@ -741,9 +970,10 @@ auto CPU::INDX() -> u16
      * X register is added to the zero-page address to get the pointer address
      * Final address is the value stored at the POINTER address
      */
-    u8 const  zero_page_address = ( Read( _pc++ ) + _x ) & 0x00FF;
-    u16 const ptr_low = Read( zero_page_address );
-    u16 const ptr_high = Read( ( zero_page_address + 1 ) & 0x00FF );
+    Tick();                                                                 // Account for operand fetch
+    u8 const  zero_page_address = ( ReadAndTick( _pc++ ) + _x ) & 0x00FF;   // 1 cycle
+    u16 const ptr_low = ReadAndTick( zero_page_address );                   // 1 cycle
+    u16 const ptr_high = ReadAndTick( ( zero_page_address + 1 ) & 0x00FF ); // 1 cycle
     return ( ptr_high << 8 ) | ptr_low;
 }
 
@@ -755,9 +985,9 @@ auto CPU::INDY() -> u16
      * The value stored at the zero-page address is the pointer address
      * The value in the Y register is added to the FINAL address
      */
-    u16 const zero_page_address = Read( _pc++ );
-    u16 const ptr_low = Read( zero_page_address );
-    u16 const ptr_high = Read( ( zero_page_address + 1 ) & 0x00FF );
+    u16 const zero_page_address = ReadAndTick( _pc++ );
+    u16 const ptr_low = ReadAndTick( zero_page_address );
+    u16 const ptr_high = ReadAndTick( ( zero_page_address + 1 ) & 0x00FF );
 
     u16 const address = ( ( ptr_high << 8 ) | ptr_low ) + _y;
 
@@ -765,7 +995,13 @@ auto CPU::INDY() -> u16
     // Instructions that should ignore this: STA
     if ( _currentPageCrossPenalty && ( address & 0xFF00 ) != ( ptr_high << 8 ) )
     {
-        _cycles++;
+        Tick();
+    }
+
+    if ( _is_write_modify )
+    {
+        // Dummy read, in preparation to overwrite the address
+        Tick();
     }
     return address;
 }
@@ -777,7 +1013,7 @@ auto CPU::REL() -> u16
      * The next byte is a signed offset
      * Sets the program counter between -128 and +127 bytes from the current location
      */
-    s8 const  offset = static_cast<s8>( Read( _pc++ ) );
+    s8 const  offset = static_cast<s8>( ReadAndTick( _pc++ ) );
     u16 const address = _pc + offset;
     return address;
 }
@@ -796,20 +1032,20 @@ void CPU::LoadRegister( u16 address, u8 &reg )
      * @brief It loads a register with a value from memory
      * Used by LDA, LDX, and LDY instructions
      */
-    u8 const value = Read( address );
+    u8 const value = ReadAndTick( address );
     reg = value;
 
     // Set zero and negative flags
     SetZeroAndNegativeFlags( value );
 };
 
-void CPU::StoreRegister( u16 address, u8 reg ) const
+void CPU::StoreRegister( u16 address, u8 reg )
 {
     /*
      * @brief It stores a register value in memory
      * Used by STA, STX, and STY instructions
      */
-    Write( address, reg );
+    WriteAndTick( address, reg );
 };
 
 void CPU::SetFlags( const u8 flag )
@@ -903,12 +1139,12 @@ void CPU::BranchOnStatus( u16 offsetAddress, u8 flag, bool isSet )
         _pc = offsetAddress;
 
         // +1 cycles because we're taking a branch
-        _cycles++;
+        Tick();
 
         // Add another cycle if page boundary is crossed
         if ( ( _pc & 0xFF00 ) != ( prev_pc & 0xFF00 ) )
         {
-            _cycles += 1;
+            Tick();
         }
     }
     // Path will not branch, nothing to do
@@ -921,7 +1157,15 @@ void CPU::CompareAddressWithRegister( u16 address, u8 reg )
      * Used by CMP, CPX, and CPY instructions
      */
 
-    u8 const value = Read( address );
+    u8 value = 0;
+    if ( _instruction_name == "*DCP" )
+    {
+        value = Read( address ); // 0 cycles
+    }
+    else
+    {
+        value = ReadAndTick( address );
+    }
 
     // Set the zero flag if the values are equal
     ( reg == value ) ? SetFlags( Status::Zero ) : ClearFlags( Status::Zero );
@@ -941,7 +1185,7 @@ void CPU::StackPush( u8 value )
      * The stack pointer is decremented and the value is written to the stack
      * Stack addresses are between 0x0100 and 0x01FF
      */
-    Write( 0x0100 + _s--, value );
+    WriteAndTick( 0x0100 + _s--, value );
 }
 
 u8 CPU::StackPop()
@@ -951,7 +1195,7 @@ u8 CPU::StackPop()
      * The stack pointer is incremented and the value is read from the stack
      * Stack addresses are between 0x0100 and 0x01FF
      */
-    return Read( 0x0100 + ++_s );
+    return ReadAndTick( 0x0100 + ++_s );
 }
 
 /*
@@ -1120,7 +1364,16 @@ void CPU::ADC( u16 address )
      * ADC Indirect X: 61(6)
      * ADC Indirect Y: 71(5+)
      */
-    u8 const value = Read( address );
+    u8 value = 0;
+
+    if ( _instruction_name == "*RRA" )
+    {
+        value = Read( address ); // No cycle spend
+    }
+    else
+    {
+        value = ReadAndTick( address );
+    }
 
     // Store the sum in a 16-bit variable to check for overflow
     u8 const  carry = IsFlagSet( Status::Carry ) ? 1 : 0;
@@ -1168,22 +1421,25 @@ void CPU::SBC( u16 address )
      * SBC Absolute Y: F9(4+)
      * SBC Indirect X: E1(6)
      * SBC Indirect Y: F1(5+)
+     *
      * --  Illegal  --
      * SBC Immediate: EB(2)
      */
 
-    u8 const value = Read( address );
+    u8 value = 0;
+    if ( _instruction_name == "*ISC" )
+    {
+        value = Read( address ); // 0 cycles
+    }
+    else
+    {
+        value = ReadAndTick( address );
+    }
+    // u8 const value = ReadAndTick( address );
 
     // Store diff in a 16-bit variable to check for overflow
     u8 const  carry = IsFlagSet( Status::Carry ) ? 0 : 1;
     u16 const diff = _a - value - carry;
-    // u8 const result = static_cast<u8>(diff & 0xFF);  // Extract lower 8 bits
-
-    // std::cout << "SBC Debug - A: " << std::hex << (int)_a
-    //           << ", Value: " << (int)value
-    //           << ", Carry: " << (int)carry
-    //           << ", Diff: " << (int)diff
-    //           << ", Result: " << (int)result << "\n";
 
     // Carry flag exists in the high byte?
     ( diff < 0x100 ) ? SetFlags( Status::Carry ) : ClearFlags( Status::Carry );
@@ -1223,10 +1479,11 @@ void CPU::INC( u16 address )
      * INC Absolute: EE(6)
      * INC Absolute X: FE(7)
      */
-    u8 const value = Read( address );
+    u8 const value = ReadAndTick( address );
+    Tick(); // Dummy write
     u8 const result = value + 1;
     SetZeroAndNegativeFlags( result );
-    Write( address, result );
+    WriteAndTick( address, result );
 }
 
 void CPU::INX( u16 address )
@@ -1269,10 +1526,11 @@ void CPU::DEC( u16 address )
      * DEC Absolute: CE(6)
      * DEC Absolute X: DE(7)
      */
-    u8 const value = Read( address );
+    u8 const value = ReadAndTick( address );
+    Tick(); // Dummy write
     u8 const result = value - 1;
     SetZeroAndNegativeFlags( result );
-    Write( address, result );
+    WriteAndTick( address, result );
 }
 
 void CPU::DEX( u16 address )
@@ -1531,7 +1789,7 @@ void CPU::PHA( const u16 address )
     const u8 stack_pointer = GetStackPointer();
 
     // Push the accumulator onto the stack
-    Write( 0x0100 + stack_pointer, GetAccumulator() );
+    WriteAndTick( 0x0100 + stack_pointer, GetAccumulator() );
 
     // Decrement the stack pointer
     SetStackPointer( stack_pointer - 1 );
@@ -1555,7 +1813,7 @@ void CPU::PHP( const u16 address )
     status |= Break;
 
     // Push the modified status register onto the stack
-    Write( 0x0100 + stack_pointer, status );
+    WriteAndTick( 0x0100 + stack_pointer, status );
 
     SetStackPointer( stack_pointer - 1 );
 }
@@ -1574,7 +1832,8 @@ void CPU::PLA( const u16 address )
     SetStackPointer( GetStackPointer() + 1 );
 
     // Get the accumulator from the stack and set the zero and negative flags
-    SetAccumulator( Read( 0x100 + GetStackPointer() ) );
+    SetAccumulator( ReadAndTick( 0x100 + GetStackPointer() ) );
+    Tick(); // Dummy read
     SetZeroAndNegativeFlags( _a );
 }
 
@@ -1591,8 +1850,9 @@ void CPU::PLP( const u16 address )
     // Increment the stack pointer first
     SetStackPointer( GetStackPointer() + 1 );
 
-    SetStatusRegister( Read( 0x100 + GetStackPointer() ) );
+    SetStatusRegister( ReadAndTick( 0x100 + GetStackPointer() ) );
     ClearFlags( Status::Break );
+    Tick(); // Dummy read
     SetFlags( Status::Unused );
 }
 
@@ -1634,7 +1894,7 @@ void CPU::ASL( u16 address )
      *   ASL Absolute X: 1E(7)
      */
 
-    if ( _imp )
+    if ( _addr_mode == "IMP" )
     {
         u8 accumulator = GetAccumulator();
         // Set the carry flag if bit 7 is set
@@ -1651,7 +1911,9 @@ void CPU::ASL( u16 address )
     }
     else
     {
-        u8 const value = Read( address );
+        u8 const value = ReadAndTick( address );
+
+        Tick(); // simulate dummy write
 
         // Set the carry flag if bit 7 is set
         ( value & 0b10000000 ) != 0 ? SetFlags( Status::Carry ) : ClearFlags( Status::Carry );
@@ -1662,7 +1924,7 @@ void CPU::ASL( u16 address )
         SetZeroAndNegativeFlags( result );
 
         // Write the result back to memory
-        Write( address, result );
+        WriteAndTick( address, result );
     }
 }
 
@@ -1679,7 +1941,7 @@ void CPU::LSR( u16 address )
      *   LSR Absolute X: 5E(7)
      */
 
-    if ( _imp )
+    if ( _addr_mode == "IMP" )
     {
         u8 accumulator = GetAccumulator();
         // Set the carry flag if bit 0 is set
@@ -1696,7 +1958,8 @@ void CPU::LSR( u16 address )
     }
     else
     {
-        u8 const value = Read( address );
+        u8 const value = ReadAndTick( address );
+        Tick(); // simulate dummy write
 
         // Set the carry flag if bit 0 is set
         ( value & 0b00000001 ) != 0 ? SetFlags( Status::Carry ) : ClearFlags( Status::Carry );
@@ -1707,7 +1970,7 @@ void CPU::LSR( u16 address )
         SetZeroAndNegativeFlags( result );
 
         // Write the result back to memory
-        Write( address, result );
+        WriteAndTick( address, result );
     }
 }
 
@@ -1725,7 +1988,7 @@ void CPU::ROL( u16 address )
      */
 
     const u8 carry = IsFlagSet( Status::Carry ) ? 1 : 0;
-    if ( _imp )
+    if ( _addr_mode == "IMP" )
     {
         u8 accumulator = GetAccumulator();
 
@@ -1746,7 +2009,8 @@ void CPU::ROL( u16 address )
     }
     else
     {
-        u8 const value = Read( address );
+        u8 const value = ReadAndTick( address );
+        Tick(); // dummy write
 
         // Set the carry flag if bit 7 is set
         ( value & 0b10000000 ) != 0 ? SetFlags( Status::Carry ) : ClearFlags( Status::Carry );
@@ -1758,7 +2022,7 @@ void CPU::ROL( u16 address )
         SetZeroAndNegativeFlags( result );
 
         // Write the result back to memory
-        Write( address, result );
+        WriteAndTick( address, result );
     }
 }
 
@@ -1777,7 +2041,7 @@ void CPU::ROR( u16 address )
 
     const u8 carry = IsFlagSet( Status::Carry ) ? 1 : 0;
 
-    if ( _imp )
+    if ( _addr_mode == "IMP" )
     { // implied mode
         u8 accumulator = GetAccumulator();
 
@@ -1798,7 +2062,8 @@ void CPU::ROR( u16 address )
     }
     else
     { // Memory mode
-        u8 const value = Read( address );
+        u8 const value = ReadAndTick( address );
+        Tick(); // simulate dummy write
 
         // Set the carry flag if bit 0 is set
         ( value & 0b00000001 ) != 0 ? SetFlags( Status::Carry ) : ClearFlags( Status::Carry );
@@ -1810,7 +2075,7 @@ void CPU::ROR( u16 address )
         SetZeroAndNegativeFlags( result );
 
         // Write the result back to memory
-        Write( address, result );
+        WriteAndTick( address, result );
     }
 }
 
@@ -1835,6 +2100,7 @@ void CPU::JSR( u16 address )
      *   JSR Absolute: 20(6)
      */
     u16 const return_address = _pc - 1;
+    Tick(); // Additional read here, probably for timing purposes
     StackPush( ( return_address >> 8 ) & 0xFF );
     StackPush( return_address & 0xFF );
     _pc = address;
@@ -1852,7 +2118,9 @@ void CPU::RTS( const u16 address )
     u16 const low = StackPop();
     u16 const high = StackPop();
     _pc = ( high << 8 ) | low;
+    Tick(); // Account for reading the new address
     _pc++;
+    Tick(); // Account for reading the next pc value
 }
 
 void CPU::RTI( const u16 address )
@@ -1872,6 +2140,7 @@ void CPU::RTI( const u16 address )
     u16 const low = StackPop();
     u16 const high = StackPop();
     _pc = ( high << 8 ) | low;
+    Tick(); // Account for reading the new address
 }
 
 void CPU::BRK( const u16 address )
@@ -1881,20 +2150,24 @@ void CPU::BRK( const u16 address )
      * from stack
      *   Usage and cycles:
      *   BRK: 00(7)
+     * Cycles:
+     *   Read opcode: 1, Read padding byte: 1
+     *   Push PC(2): 2, Push status(1): 1
+     *   Read vector low: 1, Read vector high: 1
      */
     (void) address;
     _pc++; // padding byte
 
     // Push pc to the stack
-    StackPush( _pc >> 8 );
-    StackPush( _pc & 0x00FF );
+    StackPush( _pc >> 8 );     // 1 cycle
+    StackPush( _pc & 0x00FF ); // 1 cycle
 
     // Push status with break and unused flag set (ignored when popped)
     StackPush( _p | Break | Unused );
 
     // Set PC to the value at the interrupt vector (0xFFFE)
-    u16 const low = Read( 0xFFFE );
-    u16 const high = Read( 0xFFFF );
+    u16 const low = ReadAndTick( 0xFFFE );
+    u16 const high = ReadAndTick( 0xFFFF );
     _pc = ( high << 8 ) | low;
 
     // Set the interrupt disable flag
@@ -1916,7 +2189,7 @@ void CPU::AND( u16 address )
      *   AND Indirect X: 21(6)
      *   AND Indirect Y: 31(5+)
      */
-    u8 const value = Read( address );
+    u8 const value = ReadAndTick( address );
     _a &= value;
     SetZeroAndNegativeFlags( _a );
 }
@@ -1937,7 +2210,7 @@ void CPU::ORA( const u16 address )
      *   ORA Indirect Y: 11(5+)
      */
 
-    u8 const value = Read( address );
+    u8 const value = ReadAndTick( address ); // 1 cycle
     _a |= value;
     SetZeroAndNegativeFlags( _a );
 }
@@ -1957,7 +2230,7 @@ void CPU::EOR( const u16 address )
      *   EOR Indirect X: 41(6)
      *   EOR Indirect Y: 51(5+)
      */
-    u8 const value = Read( address );
+    u8 const value = ReadAndTick( address );
     _a ^= value;
     SetZeroAndNegativeFlags( _a );
 }
@@ -1973,7 +2246,7 @@ void CPU::BIT( const u16 address )
      *   BIT Absolute: 2C(4)
      */
 
-    u8 const value = Read( address );
+    u8 const value = ReadAndTick( address );
     SetZeroAndNegativeFlags( _a & value );
 
     // Set overflow flag to bit 6 of value
@@ -2042,6 +2315,39 @@ void CPU::TYA( const u16 address )
 ||                                                            ||
 ################################################################
 */
+
+void CPU::NOP2( u16 address ) // NOLINT
+{
+    /*
+     * @brief No operation, has an additional cycle
+     * N Z C I D V
+     * - - - - - -
+     * --  Illegal  --
+     * NOP Immediate: 80(2)
+     * NOP Immediate: 82(2)
+     * NOP Immediate: 89(2)
+     * NOP Immediate: C2(2)
+     * NOP Immediate: E2(2)
+     * NOP Zero Page: 04(3)
+     * NOP Zero Page: 44(3)
+     * NOP Zero Page: 64(3)
+     * NOP Zero Page X: 14(4)
+     * NOP Zero Page X: 34(4)
+     * NOP Zero Page X: 54(4)
+     * NOP Zero Page X: 74(4)
+     * NOP Zero Page X: D4(4)
+     * NOP Zero Page X: F4(4)
+     * NOP Absolute: 0C(4)
+     * NOP Absolute: 1C(4)
+     * NOP Absolute: 3C(4)
+     * NOP Absolute: 5C(4)
+     * NOP Absolute: 7C(4)
+     * NOP Absolute: DC(4)
+     * NOP Absolute: FC(4)
+     */
+    Tick();
+    (void) address;
+}
 void CPU::JAM( const u16 address ) // NOLINT
 {
     /* @brief Illegal Opcode
@@ -2049,11 +2355,13 @@ void CPU::JAM( const u16 address ) // NOLINT
      * Tom Harte tests include these, though, so for completeness, we'll add them
      */
     (void) address;
-
-    // Do nothing
+    for ( int i = 0; i < 9; i++ )
+    {
+        Tick();
+    }
 }
 
-void CPU::SLO( const u16 address ) // NOLINT
+void CPU::SLO( const u16 address )
 {
     /* @brief Illegal opcode: combines ASL and ORA
      * N Z C I D V
@@ -2068,7 +2376,11 @@ void CPU::SLO( const u16 address ) // NOLINT
      *   SLO Indirect Y: 13(8)
      */
     CPU::ASL( address );
-    CPU::ORA( address );
+
+    // ORA is side effect, no cycles are spent
+    u8 const value = Read( address ); // 0 cycle
+    _a |= value;
+    SetZeroAndNegativeFlags( _a );
 }
 
 void CPU::SAX( const u16 address ) // NOLINT
@@ -2082,7 +2394,7 @@ void CPU::SAX( const u16 address ) // NOLINT
      *   SAX Indirect X: 83(6)
      *   SAX Absolute: 8F(4)
      */
-    Write( address, _a & _x );
+    WriteAndTick( address, _a & _x );
 }
 
 void CPU::LXA( const u16 address )
@@ -2095,7 +2407,7 @@ void CPU::LXA( const u16 address )
      */
 
     u8 const magic_constant = 0xEE;
-    u8 const value = Read( address );
+    u8 const value = ReadAndTick( address );
 
     u8 const result = ( ( _a | magic_constant ) & value );
     _a = result;
@@ -2116,8 +2428,10 @@ void CPU::LAX( const u16 address )
      *   LAX Indirect X: A3(6)
      *   LAX Indirect Y: B3(5+)
      */
-    LDA( address );
-    LDX( address );
+    u8 const value = ReadAndTick( address );
+    SetAccumulator( value );
+    SetXRegister( value );
+    SetZeroAndNegativeFlags( value );
 }
 
 void CPU::ARR( const u16 address )
@@ -2128,42 +2442,26 @@ void CPU::ARR( const u16 address )
      *   Usage and cycles:
      *   ARR Immediate: 6B(2)
      */
-    u8 const value = Read( address );
 
-    // Perform AND with accumulator
-    _a &= value;
+    // A & operand
+    u8 value = _a & ReadAndTick( address );
 
-    // Grab carry-in if carry flag is set
-    u8 const carry_in = IsFlagSet( Carry ) ? 0x80 : 0x00;
+    // ROR
+    u8 const carry_in = IsFlagSet( Status::Carry ) ? 0x80 : 0x00;
+    value = ( value >> 1 ) | carry_in;
 
-    // Perform ROR on the result
-    u8 const result = ( _a >> 1 ) | carry_in;
+    _a = value;
 
-    // Set accumulator to the result
-    _a = result;
-
-    // Set zero and negative flags
+    // Set flags
     SetZeroAndNegativeFlags( _a );
 
-    // Set carry flag based on 6th bit of accumulator
-    if ( ( _a & 0x40 ) != 0 )
-    {
-        SetFlags( Carry );
-    }
-    else
-    {
-        ClearFlags( Carry );
-    }
+    // Adjust C and V flags according to the ARR rules
+    // C = bit 6 of A
+    ( _a & 0x40 ) != 0 ? SetFlags( Status::Carry ) : ClearFlags( Status::Carry );
 
-    // Set overflow flag based on XOR of bits 6 and 5
-    if ( ( ( ( _a >> 6 ) ^ ( _a >> 5 ) ) & 0x01 ) != 0 )
-    {
-        SetFlags( Overflow );
-    }
-    else
-    {
-        ClearFlags( Overflow );
-    }
+    // V = bit 5 XOR bit 6
+    bool const is_overflow = ( ( _a & 0x40 ) != 0 ) ^ ( ( _a & 0x20 ) != 0 );
+    ( is_overflow ) ? SetFlags( Status::Overflow ) : ClearFlags( Status::Overflow );
 }
 
 void CPU::ALR( const u16 address )
@@ -2174,26 +2472,13 @@ void CPU::ALR( const u16 address )
      *   Usage and cycles:
      *   ALR Immediate: 4B(2)
      */
-    u8 const value = Read( address );
+    CPU::AND( address );
 
-    // Perform AND with accumulator
-    _a &= value;
-
-    // Set carry flag based on least significant bit
-    if ( ( _a & 0x01 ) != 0 )
-    {
-        SetFlags( Carry );
-    }
-    else
-    {
-        ClearFlags( Carry );
-    }
-
-    // Shift right by 1 bit
-    _a >>= 1;
-
-    // Set zero and negative flags
-    SetZeroAndNegativeFlags( _a );
+    u8 const value = GetAccumulator();
+    ( value & 0b00000001 ) != 0 ? SetFlags( Status::Carry ) : ClearFlags( Status::Carry );
+    u8 const result = value >> 1;
+    SetZeroAndNegativeFlags( result );
+    _a = result;
 }
 
 void CPU::RRA( const u16 address )
@@ -2210,30 +2495,8 @@ void CPU::RRA( const u16 address )
      *   RRA Indirect X: 63(8)
      *   RRA Indirect Y: 73(8)
      */
-    // First, read the value and perform ROR
-    u8 const value = Read( address );
-
-    // Grab carry-in if carry flag is set
-    u8 const carry_in = IsFlagSet( Carry ) ? 0x80 : 0x00;
-
-    // Perform ROR
-    u8 const ror_result = ( value >> 1 ) | carry_in;
-
-    // Write back the ROR result
-    Write( address, ror_result );
-
-    // Set carry flag based on least significant bit of original value
-    if ( ( value & 0x01 ) != 0 )
-    {
-        SetFlags( Carry );
-    }
-    else
-    {
-        ClearFlags( Carry );
-    }
-
-    // Now perform ADC with the ROR result
-    ADC( address );
+    CPU::ROR( address );
+    CPU::ADC( address );
 }
 
 void CPU::SRE( const u16 address )
@@ -2250,33 +2513,17 @@ void CPU::SRE( const u16 address )
      *   SRE Indirect X: 43(8)
      *   SRE Indirect Y: 53(8)
      */
-    // First, read the value and perform LSR
-    u8 const value = Read( address );
+    CPU::LSR( address );
 
-    // Set carry flag based on least significant bit
-    if ( ( value & 0x01 ) != 0 )
-    {
-        SetFlags( Carry );
-    }
-    else
-    {
-        ClearFlags( Carry );
-    }
-
-    // Perform LSR
-    u8 const lsr_result = value >> 1;
-
-    // Write back the LSR result
-    Write( address, lsr_result );
-
-    // Now perform EOR with the LSR result
-    EOR( address );
+    // Free side effect
+    u8 const value = Read( address ); // 0 cycle
+    _a ^= value;
+    SetZeroAndNegativeFlags( _a );
 }
 
-void CPU::RLA( u16 address )
+void CPU::RLA( const u16 address )
 {
-    /*
-     * @brief Illegal opcode: combines ROL and AND
+    /* @brief Illegal opcode: combines ROL and AND
      * N Z C I D V
      * + + + - - -
      *   Usage and cycles:
@@ -2288,34 +2535,15 @@ void CPU::RLA( u16 address )
      *   RLA Indirect X: 23(8)
      *   RLA Indirect Y: 33(8)
      */
-    // read value for ROL
-    u8 value = Read( address );
+    CPU::ROL( address );
 
-    // check carry-in from flag
-    u8 const carry_in = IsFlagSet( Carry ) ? 1 : 0;
-
-    // rotate left
-    if ( ( value & 0b10000000 ) != 0 )
-    {
-        SetFlags( Carry ); // if most significant bit is set
-    }
-    else
-    {
-        ClearFlags( Carry );
-    }
-    // set ROL by shifting left one bit
-    value = ( value << 1 ) | carry_in;
-
-    // write ROL to memory
-    Write( address, value );
-
-    // use AND with accumulator
+    // Free side effect
+    u8 const value = Read( address ); // 0 cycle
     _a &= value;
-
     SetZeroAndNegativeFlags( _a );
 }
 
-void CPU::DCP( u16 address )
+void CPU::DCP( const u16 address )
 {
     /* @brief Illegal opcode: combines DEC and CMP
      * N Z C I D V
@@ -2329,27 +2557,8 @@ void CPU::DCP( u16 address )
      *   DCP Indirect X: C3(8)
      *   DCP Indirect Y: D3(8)
      */
-    // decrement value in memory
-    u8 value = Read( address );
-
-    // decrement in memory
-    value = value - 1;
-    Write( address, value );
-
-    // CMP with value
-    u8 const result = _a - value;
-
-    // set carry flag
-    if ( _a >= value )
-    {
-        SetFlags( Status::Carry );
-    }
-    else
-    {
-        ClearFlags( Status::Carry );
-    }
-
-    SetZeroAndNegativeFlags( result );
+    CPU::DEC( address );
+    CPU::CMP( address );
 }
 
 void CPU::ISC( const u16 address )
@@ -2366,49 +2575,38 @@ void CPU::ISC( const u16 address )
      *   ISC Indirect X: E3(8)
      *   ISC Indirect Y: F3(8)
      */
-
-    // read from memory
-    u8 value = Read( address );
-
-    // increment the value that was read
-    value = value + 1;
-    Write( address, value );
-
-    // complete SBC operation
-    u8 const carry = IsFlagSet( Status::Carry ) ? 0 : 1;
-    u8 const result = _a - value - carry;
-
-    // update the carry flag
-    if ( _a >= ( value + carry ) )
-    {
-        SetFlags( Carry );
-    }
-    else
-    {
-        ClearFlags( Carry );
-    }
-
-    // update the overflow flag
-    if ( ( ( _a ^ value ) & 0x80 ) && ( ( _a ^ result ) & 0x80 ) )
-    {
-        SetFlags( Overflow );
-    }
-    else
-    {
-        ClearFlags( Overflow );
-    }
-
-    // update accumulator
-    _a = result;
-
-    SetZeroAndNegativeFlags( _a );
+    CPU::INC( address );
+    CPU::SBC( address );
 }
 
-void CPU::ANC( u16 address )
+void CPU::ANC( const u16 address )
 {
-    // Explicitly call AND method
-    AND( address );
-
-    // Set Carry flag based on Negative flag
+    /* @brief Illegal opcode: combines AND and Carry
+     * N Z C I D V
+     * + + + - - -
+     *   Usage and cycles:
+     *   ANC Immediate: 0B(2)
+     *   ANC Immediate: 2B(2)
+     */
+    CPU::AND( address );
     ( IsFlagSet( Status::Negative ) ) ? SetFlags( Status::Carry ) : ClearFlags( Status::Carry );
+}
+
+void CPU::SBX( const u16 address )
+{
+    /* @brief Illegal opcode: SBX (a.k.a. AXS) combines CMP and DEX
+     *        (A & X) - immediate -> X
+     * Sets flags like CMP:
+     *   N Z C I D V
+     *   + + + - - -
+     *
+     * Usage and cycles:
+     *   SBX Immediate: CB (2 bytes, 2 cycles)
+     */
+    u8 const  operand = ReadAndTick( address );
+    u8 const  left = ( _a & _x );
+    u16 const diff = static_cast<uint16_t>( left ) - static_cast<uint16_t>( operand );
+    _x = static_cast<u8>( diff & 0xFF );
+    ( ( diff & 0x100 ) == 0 ) ? SetFlags( Status::Carry ) : ClearFlags( Status::Carry );
+    SetZeroAndNegativeFlags( _x );
 }

--- a/src/ppu.cpp
+++ b/src/ppu.cpp
@@ -24,6 +24,7 @@ PPU::PPU( Bus *bus, bool isDisabled ) : _isDisabled( isDisabled ), _bus( bus ) {
 */
 void PPU::SetScanline( s16 scanline ) { _scanline = scanline; }
 void PPU::SetCycles( u16 cycles ) { _cycle = cycles; }
+void PPU::SetIsCpuReadingPpuStatus( bool isReading ) { _isCpuReadingPpuStatus = isReading; }
 
 /*
 ################################
@@ -380,7 +381,7 @@ void PPU::Write( u16 address, u8 data ) // NOLINT
 */
 void PPU::Tick() // NOLINT
 {
-    if ( _isDisabled )
+    if ( _isDisabled || _bus->IsTestMode() )
     {
         return;
     }
@@ -404,7 +405,17 @@ void PPU::Tick() // NOLINT
     ||       End Of Scanline      ||
     ################################
     */
-    // TODO: Implement
+    if ( _cycle > 340 )
+    {
+        _cycle = 0;
+        _scanline++;
+
+        if ( _scanline > 260 )
+        {
+            _scanline = -1;
+            _frame++;
+        }
+    }
 
     /*
     ################################

--- a/tests/cpu_test.cpp
+++ b/tests/cpu_test.cpp
@@ -582,22 +582,14 @@ CPU_TEST( F8, SED, Implied, "f8.json" );
 
 /*
 ################################
-||                            ||
 ||       Illegal Opcodes      ||
-||                            ||
 ################################
 */
-
-/* Illegal Jam
- * These will jam the hardware are are generally not used.
- * These should still be tested. They should not have any effect
- */
 CPU_TEST( 02, JAM, Implied, "02.json" );
 CPU_TEST( 12, JAM, Implied, "12.json" );
 CPU_TEST( 22, JAM, Implied, "22.json" );
 CPU_TEST( 32, JAM, Implied, "32.json" );
 CPU_TEST( 42, JAM, Implied, "42.json" );
-CPU_TEST( 45, JAM, Implied, "42.json" );
 CPU_TEST( 52, JAM, Implied, "52.json" );
 CPU_TEST( 62, JAM, Implied, "62.json" );
 CPU_TEST( 72, JAM, Implied, "72.json" );
@@ -605,8 +597,6 @@ CPU_TEST( 92, JAM, Implied, "92.json" );
 CPU_TEST( B2, JAM, Implied, "b2.json" );
 CPU_TEST( D2, JAM, Implied, "d2.json" );
 CPU_TEST( F2, JAM, Implied, "f2.json" );
-
-/* Illegal NOP */
 CPU_TEST( 1A, NOP, Implied, "1a.json" );
 CPU_TEST( 3A, NOP, Implied, "3a.json" );
 CPU_TEST( 5A, NOP, Implied, "5a.json" );
@@ -634,11 +624,6 @@ CPU_TEST( 5C, NOP, AbsoluteX, "5c.json" );
 CPU_TEST( 7C, NOP, AbsoluteX, "7c.json" );
 CPU_TEST( DC, NOP, AbsoluteX, "dc.json" );
 CPU_TEST( FC, NOP, AbsoluteX, "fc.json" );
-
-/* Illegal SBC */
-CPU_TEST( EB, SBC, Immediate, "eb.json" );
-
-/* Illegal SL0 */
 CPU_TEST( 07, SLO, ZeroPage, "07.json" );
 CPU_TEST( 17, SLO, ZeroPageX, "17.json" );
 CPU_TEST( 0F, SLO, Absolute, "0f.json" );
@@ -646,8 +631,6 @@ CPU_TEST( 1F, SLO, AbsoluteX, "1f.json" );
 CPU_TEST( 1B, SLO, AbsoluteY, "1b.json" );
 CPU_TEST( 03, SLO, IndirectX, "03.json" );
 CPU_TEST( 13, SLO, IndirectY, "13.json" );
-
-/* Illegal RLA */
 CPU_TEST( 27, RLA, ZeroPage, "27.json" );
 CPU_TEST( 37, RLA, ZeroPageX, "37.json" );
 CPU_TEST( 2F, RLA, Absolute, "2f.json" );
@@ -655,8 +638,6 @@ CPU_TEST( 3F, RLA, AbsoluteX, "3f.json" );
 CPU_TEST( 3B, RLA, AbsoluteY, "3b.json" );
 CPU_TEST( 23, RLA, IndirectX, "23.json" );
 CPU_TEST( 33, RLA, IndirectY, "33.json" );
-
-/* Illegal SRE */
 CPU_TEST( 47, SRE, ZeroPage, "47.json" );
 CPU_TEST( 57, SRE, ZeroPageX, "57.json" );
 CPU_TEST( 4F, SRE, Absolute, "4f.json" );
@@ -664,8 +645,6 @@ CPU_TEST( 5F, SRE, AbsoluteX, "5f.json" );
 CPU_TEST( 5B, SRE, AbsoluteY, "5b.json" );
 CPU_TEST( 43, SRE, IndirectX, "43.json" );
 CPU_TEST( 53, SRE, IndirectY, "53.json" );
-
-/* Illegal RRA */
 CPU_TEST( 67, RRA, ZeroPage, "67.json" );
 CPU_TEST( 77, RRA, ZeroPageX, "77.json" );
 CPU_TEST( 6F, RRA, Absolute, "6f.json" );
@@ -673,25 +652,16 @@ CPU_TEST( 7F, RRA, AbsoluteX, "7f.json" );
 CPU_TEST( 7B, RRA, AbsoluteY, "7b.json" );
 CPU_TEST( 63, RRA, IndirectX, "63.json" );
 CPU_TEST( 73, RRA, IndirectY, "73.json" );
-
-/* Illegal SAX */
 CPU_TEST( 87, SAX, ZeroPage, "87.json" );
 CPU_TEST( 97, SAX, ZeroPageY, "97.json" );
 CPU_TEST( 8F, SAX, Absolute, "8f.json" );
 CPU_TEST( 83, SAX, IndirectX, "83.json" );
-
-/* Illegal LXA */
-CPU_TEST( AB, LXA, Immediate, "ab.json" );
-
-/* Illegal LAX */
 CPU_TEST( A7, LAX, ZeroPage, "a7.json" );
 CPU_TEST( B7, LAX, ZeroPageY, "b7.json" );
 CPU_TEST( AF, LAX, Absolute, "af.json" );
 CPU_TEST( BF, LAX, AbsoluteY, "bf.json" );
 CPU_TEST( A3, LAX, IndirectX, "a3.json" );
 CPU_TEST( B3, LAX, IndirectY, "b3.json" );
-
-/* Illegal DCP */
 CPU_TEST( C7, DCP, ZeroPage, "c7.json" );
 CPU_TEST( D7, DCP, ZeroPageX, "d7.json" );
 CPU_TEST( CF, DCP, Absolute, "cf.json" );
@@ -699,8 +669,6 @@ CPU_TEST( DF, DCP, AbsoluteX, "df.json" );
 CPU_TEST( DB, DCP, AbsoluteY, "db.json" );
 CPU_TEST( C3, DCP, IndirectX, "c3.json" );
 CPU_TEST( D3, DCP, IndirectY, "d3.json" );
-
-/* Illegal ISC */
 CPU_TEST( E7, ISC, ZeroPage, "e7.json" );
 CPU_TEST( F7, ISC, ZeroPageX, "f7.json" );
 CPU_TEST( EF, ISC, Absolute, "ef.json" );
@@ -708,17 +676,13 @@ CPU_TEST( FF, ISC, AbsoluteX, "ff.json" );
 CPU_TEST( FB, ISC, AbsoluteY, "fb.json" );
 CPU_TEST( E3, ISC, IndirectX, "e3.json" );
 CPU_TEST( F3, ISC, IndirectY, "f3.json" );
-
-/* Illegal ALR */
 CPU_TEST( 4B, ALR, Immediate, "4b.json" );
-
-/* Illegal ARR */
 CPU_TEST( 6B, ARR, Immediate, "6b.json" );
-
-/* Illegal ANC */ 
+CPU_TEST( EB, USBC, Immediate, "eb.json" );
 CPU_TEST( 0B, ANC, Immediate, "0b.json" );
-CPU_TEST( 2B, ANC, AbsoluteX, "2b.json" );
-
+CPU_TEST( 2B, ANC, Immediate, "2b.json" );
+CPU_TEST( AB, LXA, Immediate, "ab.json" );
+CPU_TEST( CB, SBX, Immediate, "cb.json" );
 /*
 ################################################################
 ||                                                            ||
@@ -750,7 +714,7 @@ void CPUTestFixture::RunTestCase( const json &testCase ) // NOLINT
     }
 
     // Fetch, decode, execute
-    cpu.Tick();
+    cpu.DecodeExecute();
 
     // Check final state
     bool               test_failed = false; // Track if any test has failed


### PR DESCRIPTION
Closes #126
Closes #125
Closes #116

- Implemented more accurate instruction tracking
- Finished the Nestest ROM with all passing tests. You can run it with `./scripts/test.sh "RomTests.Nestest"`. This test covers all the official instructions and most of the unofficial instructions, minus a couple obscure ones. The output log is saved in `tests/output` after each run, and it shows the CPU state at every tick.
- Added PPU end of scanline behavior, which increments ppu cycles, scanlines, and frames. I was going to leave this on the board for someone else, but I ended up needing it.
- Small refactors here and there. Check the commit log for more details

