### PR TITLE
Implemented hex memory viewer

### DIFF
--- a/frontend/ui-manager.cpp
+++ b/frontend/ui-manager.cpp
@@ -7,6 +7,7 @@
 #include "overlay.h"
 #include "debugger.h"
 #include "log.h"
+#include "memory-display.h"
 
 UIManager::UIManager( Renderer *renderer )
 {
@@ -15,6 +16,7 @@ UIManager::UIManager( Renderer *renderer )
     AddComponent<DemoWindow>( renderer );
     AddComponent<DebuggerWindow>( renderer );
     AddComponent<LogWindow>( renderer );
+    AddComponent<MemoryDisplayWindow>( renderer );
 }
 
 void UIManager::Render()

--- a/frontend/ui/main-menubar.h
+++ b/frontend/ui/main-menubar.h
@@ -39,7 +39,7 @@ class MainMenuBar : public UIComponent
                 if ( auto *logWindow = ui->GetComponent<LogWindow>() ) {
                     ImGui::MenuItem( "Trace Log", nullptr, &logWindow->visible );
                 }
-                
+
                 if ( auto *memoryDisplayWindow = ui->GetComponent<MemoryDisplayWindow>() ) {
                     ImGui::MenuItem( "Memory Display", nullptr, &memoryDisplayWindow->visible );
                 }

--- a/frontend/ui/main-menubar.h
+++ b/frontend/ui/main-menubar.h
@@ -8,6 +8,7 @@
 #include "debugger.h"
 #include "overlay.h"
 #include "log.h"
+#include "memory-display.h"
 
 class MainMenuBar : public UIComponent
 {
@@ -37,6 +38,10 @@ class MainMenuBar : public UIComponent
 
                 if ( auto *logWindow = ui->GetComponent<LogWindow>() ) {
                     ImGui::MenuItem( "Trace Log", nullptr, &logWindow->visible );
+                }
+                
+                if ( auto *memoryDisplayWindow = ui->GetComponent<MemoryDisplayWindow>() ) {
+                    ImGui::MenuItem( "Memory Display", nullptr, &memoryDisplayWindow->visible );
                 }
 
                 ImGui::EndMenu();

--- a/frontend/ui/memory-display.h
+++ b/frontend/ui/memory-display.h
@@ -1,0 +1,129 @@
+#pragma once
+#include "ui-component.h"
+#include "renderer.h"
+#include <imgui.h>
+
+class MemoryDisplayWindow : public UIComponent
+{
+  public:
+    MemoryDisplayWindow( Renderer *renderer ) : UIComponent( renderer ) { visible = false; }
+
+    void RenderSelf() override
+    {
+        ImGuiWindowFlags windowFlags =
+            ImGuiWindowFlags_MenuBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_AlwaysAutoResize;
+        ImGui::PushStyleVar( ImGuiStyleVar_WindowPadding, ImVec2( 10.0f, 10.0f ) );
+        ImGui::SetNextWindowSizeConstraints( ImVec2( 600, -1 ), ImVec2( 800, -1 ) );
+
+        if ( ImGui::Begin( "Memory Viewer", &visible, windowFlags ) ) {
+            RenderMenuBar();
+            bool isPaused = renderer->paused;
+
+            ImGui::BeginDisabled( !isPaused );
+            ImGui::PushItemWidth( 140 );
+            if ( ImGui::Button( "Continue" ) ) {
+                renderer->paused = false;
+            }
+            ImGui::EndDisabled();
+
+            ImGui::SameLine();
+
+            ImGui::BeginDisabled( isPaused );
+            if ( ImGui::Button( "Pause" ) ) {
+                renderer->paused = true;
+            }
+            ImGui::EndDisabled();
+
+            ImGui::SameLine();
+
+            if ( ImGui::Button( "Reset" ) ) {
+                renderer->bus.DebugReset();
+            }
+
+            ImGui::SameLine();
+            ImGui::Text( "CPU Cycle: %lld", renderer->bus.cpu.GetCycles() );
+            ImGui::PopItemWidth();
+            
+
+            // Eventually we can add in PPU memory, etc. here
+            const char *items[] = {
+                "CPU Memory",
+                "PPU Memory"
+            };
+            static int item_selected_idx = 0;
+
+            const char* combo_preview = items[item_selected_idx];
+            if (ImGui::BeginCombo("Memory Type", combo_preview)) {
+                for (int n = 0; n < IM_ARRAYSIZE(items); n++) {
+                    const bool is_selected = (item_selected_idx == n);
+                    if (ImGui::Selectable(items[n], is_selected)) {
+                        item_selected_idx = n;
+                    }
+                    if (is_selected) {
+                        ImGui::SetItemDefaultFocus();
+                    }
+                }
+                ImGui::EndCombo();
+            }
+
+            if (item_selected_idx == 0) {
+                ImGui::Text("CPU Memory:");
+                ImGui::BeginChild("CPU Memory", ImVec2(0, 260), true, ImGuiWindowFlags_HorizontalScrollbar);
+            
+                // Use ImGui table to enforce column alignment
+                if (ImGui::BeginTable("MemoryTable", 17, ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg)) {
+                    ImGui::TableSetupColumn("", ImGuiTableColumnFlags_WidthFixed, 40);
+
+                    // One column for each byte
+                    for (int j = 0; j < 16; j++) {
+                        char colName[4];
+                        snprintf(colName, sizeof(colName), "%02X", j);
+                        ImGui::TableSetupColumn(colName, ImGuiTableColumnFlags_WidthFixed, 20);
+                    }
+                    ImGui::TableHeadersRow();
+            
+                    // Memory display
+                    for (int i = 0; i < 0x10000; i += 16) {
+                        ImGui::TableNextRow();
+                        
+                        // Address column
+                        ImGui::TableSetColumnIndex(0);
+                        ImGui::Text("%04X", i);
+
+                        // Hex byte columns
+                        for (int j = 0; j < 16; j++) {
+                            uint8_t byte = renderer->bus.cpu.Read(i + j);
+
+                            ImGui::TableSetColumnIndex(j + 1);
+                            ImGui::Text("%02X", byte);
+                        }
+                    }
+            
+                    ImGui::EndTable();
+                }
+            
+                ImGui::EndChild();
+            }
+        }
+
+        
+        ImGui::End();
+        ImGui::PopStyleVar();
+    }
+
+  private:
+    bool _cycleBreakpoint = false;
+
+    void RenderMenuBar()
+    {
+        if ( ImGui::BeginMenuBar() ) {
+            if ( ImGui::BeginMenu( "File" ) ) {
+                if ( ImGui::MenuItem( "Exit" ) ) {
+                    visible = false;
+                }
+                ImGui::EndMenu();
+            }
+            ImGui::EndMenuBar();
+        }
+    }
+};

--- a/frontend/ui/memory-display.h
+++ b/frontend/ui/memory-display.h
@@ -2,6 +2,7 @@
 #include "ui-component.h"
 #include "renderer.h"
 #include <imgui.h>
+#include <functional>
 
 class MemoryDisplayWindow : public UIComponent
 {
@@ -16,6 +17,8 @@ class MemoryDisplayWindow : public UIComponent
         ImGui::SetNextWindowSizeConstraints( ImVec2( 600, -1 ), ImVec2( 800, -1 ) );
 
         if ( ImGui::Begin( "Memory Viewer", &visible, windowFlags ) ) {
+
+            // Used Bogdan's code for the continue/pause/reset logic as well as CPU cycle tracking
             RenderMenuBar();
             bool isPaused = renderer->paused;
 
@@ -43,77 +46,68 @@ class MemoryDisplayWindow : public UIComponent
             ImGui::SameLine();
             ImGui::Text( "CPU Cycle: %lld", renderer->bus.cpu.GetCycles() );
             ImGui::PopItemWidth();
-            
 
-            // Eventually we can add in PPU memory, etc. here
-            const char *items[] = {
-                "CPU Memory",
-                "PPU Memory"
+            // Add new items here
+            const char *items[] = { "CPU Memory", "PPU Memory" };
+
+            // Default to CPU Memory parameters
+            static int         item_selected_idx = 0;
+            static const char *header = "CPU Memory:";
+            static const char *child_name = "CPU Memory";
+            static int         lower_bound = 0;
+            static int         upper_bound = 0xFFFF;
+            static int         step = 16;
+            // Use a lambda to capture the renderer instance
+            static std::function<uint8_t( int )> read_func = [&]( int address ) -> uint8_t {
+                return renderer->bus.cpu.Read( address );
             };
-            static int item_selected_idx = 0;
 
-            const char* combo_preview = items[item_selected_idx];
-            if (ImGui::BeginCombo("Memory Type", combo_preview)) {
-                for (int n = 0; n < IM_ARRAYSIZE(items); n++) {
-                    const bool is_selected = (item_selected_idx == n);
-                    if (ImGui::Selectable(items[n], is_selected)) {
+            // Build the ComboBox
+            const char *combo_preview = items[item_selected_idx];
+            if ( ImGui::BeginCombo( "Memory Type", combo_preview ) ) {
+                for ( int n = 0; n < IM_ARRAYSIZE( items ); n++ ) {
+                    const bool is_selected = ( item_selected_idx == n );
+                    if ( ImGui::Selectable( items[n], is_selected ) ) {
                         item_selected_idx = n;
                     }
-                    if (is_selected) {
+                    if ( is_selected ) {
                         ImGui::SetItemDefaultFocus();
                     }
                 }
                 ImGui::EndCombo();
             }
 
-            if (item_selected_idx == 0) {
-                ImGui::Text("CPU Memory:");
-                ImGui::BeginChild("CPU Memory", ImVec2(0, 260), true, ImGuiWindowFlags_HorizontalScrollbar);
-            
-                // Use ImGui table to enforce column alignment
-                if (ImGui::BeginTable("MemoryTable", 17, ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg)) {
-                    ImGui::TableSetupColumn("", ImGuiTableColumnFlags_WidthFixed, 40);
-
-                    // One column for each byte
-                    for (int j = 0; j < 16; j++) {
-                        char colName[4];
-                        snprintf(colName, sizeof(colName), "%02X", j);
-                        ImGui::TableSetupColumn(colName, ImGuiTableColumnFlags_WidthFixed, 20);
-                    }
-                    ImGui::TableHeadersRow();
-            
-                    // Memory display
-                    for (int i = 0; i < 0x10000; i += 16) {
-                        ImGui::TableNextRow();
-                        
-                        // Address column
-                        ImGui::TableSetColumnIndex(0);
-                        ImGui::Text("%04X", i);
-
-                        // Hex byte columns
-                        for (int j = 0; j < 16; j++) {
-                            uint8_t byte = renderer->bus.cpu.Read(i + j);
-
-                            ImGui::TableSetColumnIndex(j + 1);
-                            ImGui::Text("%02X", byte);
-                        }
-                    }
-            
-                    ImGui::EndTable();
-                }
-            
-                ImGui::EndChild();
+            // Assign parameters here for different memory types
+            switch ( item_selected_idx ) {
+                case 0:
+                    header = "CPU Memory:";
+                    child_name = "CPU Memory";
+                    lower_bound = 0x0000;
+                    upper_bound = 0xFFFF;
+                    step = 16;
+                    read_func = [&]( int address ) -> uint8_t { return renderer->bus.cpu.Read( address ); };
+                    break;
+                case 1:
+                    header = "PPU Memory:";
+                    child_name = "PPU Memory";
+                    lower_bound = 0x0000;
+                    upper_bound = 0x3FFF;
+                    step = 16;
+                    read_func = [&]( int address ) -> uint8_t { return renderer->bus.ppu.Read( address ); };
+                    break;
+                default:
+                    break;
             }
+
+            // Render the table using the above parameters
+            RenderTable( header, child_name, lower_bound, upper_bound, step, read_func );
         }
 
-        
         ImGui::End();
         ImGui::PopStyleVar();
     }
 
   private:
-    bool _cycleBreakpoint = false;
-
     void RenderMenuBar()
     {
         if ( ImGui::BeginMenuBar() ) {
@@ -125,5 +119,59 @@ class MemoryDisplayWindow : public UIComponent
             }
             ImGui::EndMenuBar();
         }
+    }
+
+    /**
+     * @brief Renders a memory table using ImGui.
+     *
+     * This function displays a table with memory addresses and their corresponding byte values.
+     * The table includes a header, a child window, and columns for each byte.
+     *
+     * @param header The header text to display above the table.
+     * @param child_name The name of the child window.
+     * @param lower_bound The starting address of the memory range to display.
+     * @param upper_bound The ending address of the memory range to display.
+     * @param step The step size between memory addresses.
+     * @param read_func A function that reads a byte from a given memory address.
+     */
+    void RenderTable( const char *header, const char *child_name, int lower_bound, int upper_bound, int step,
+                      std::function<uint8_t( int )> read_func )
+    {
+        ImGui::Text( "%s", header );
+        ImGui::BeginChild( child_name, ImVec2( 0, 300 ), true );
+
+        // Use ImGui table to enforce column alignment
+        if ( ImGui::BeginTable( "MemoryTable", 17, ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg ) ) {
+            ImGui::TableSetupColumn( "", ImGuiTableColumnFlags_WidthFixed, 40 );
+
+            // One column for each byte
+            for ( int j = 0; j < 16; j++ ) {
+                char colName[4];
+                snprintf( colName, sizeof( colName ), "%02X", j );
+                ImGui::TableSetupColumn( colName, ImGuiTableColumnFlags_WidthFixed, 20 );
+            }
+            ImGui::TableHeadersRow();
+
+            // Memory display
+            for ( int i = lower_bound; i <= upper_bound; i += step ) {
+                ImGui::TableNextRow();
+
+                // Address column
+                ImGui::TableSetColumnIndex( 0 );
+                ImGui::Text( "%04X", i );
+
+                // Hex byte columns
+                for ( int j = 0; j < 16; j++ ) {
+                    uint8_t byte = read_func( i + j );
+
+                    ImGui::TableSetColumnIndex( j + 1 );
+                    ImGui::Text( "%02X", byte );
+                }
+            }
+
+            ImGui::EndTable();
+        }
+
+        ImGui::EndChild();
     }
 };

--- a/frontend/ui/memory-display.h
+++ b/frontend/ui/memory-display.h
@@ -7,7 +7,7 @@
 class MemoryDisplayWindow : public UIComponent
 {
   public:
-    MemoryDisplayWindow( Renderer *renderer ) : UIComponent( renderer ) { visible = false; }
+    MemoryDisplayWindow( Renderer *renderer ) : UIComponent( renderer ) { visible = true; }
 
     void RenderSelf() override
     {

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -41,7 +41,7 @@ lint)
   if [ -z "${CI:-}" ]; then
     # In local mode, automatically fix formatting
     echo "Running clang-format locally and fixing formatting..."
-    for file in $(find core/ include/ -name '*.cpp' -o -name '*.h'); do
+    for file in $(find core/ include/ frontend/ -name '*.cpp' -o -name '*.h'); do
       clang-format -i "$file"
     done
 
@@ -49,7 +49,7 @@ lint)
     # In CI, check formatting without fixing
     echo "Running clang-format in CI mode (check only)..."
     format_failures=0
-    for file in $(find core/ include/ -name '*.cpp' -o -name '*.h'); do
+    for file in $(find core/ include/ frontend/ -name '*.cpp' -o -name '*.h'); do
       # Check if clang-format changes the file
       if ! clang-format "$file" | diff -u "$file" - >/dev/null; then
         echo "Formatting issues found in $file"


### PR DESCRIPTION
Right now, the memory viewer supports CPU and PPU memory. Follow the implementation in memory-display.h to extend the capabilities.

Also added the frontend directory to the linting flow.