### PR TITLE
Fixed cycle bug

### DIFF
--- a/core/cpu.cpp
+++ b/core/cpu.cpp
@@ -732,7 +732,7 @@ void CPU::DecodeExecute()
 void CPU::ExecuteFrame( bool *isPaused ) // NOLINT
 {
     _isPaused = *isPaused;
-    u16 const currentFrame = _bus->ppu.GetFrame();
+    u64 const currentFrame = _bus->ppu.GetFrame();
     while ( currentFrame == _bus->ppu.GetFrame() ) {
         if ( _isPaused ) {
             break;


### PR DESCRIPTION
Fixes #165

The problem was here
```cpp
// cpu.cpp
void CPU::ExecuteFrame( bool *isPaused ) // NOLINT
{
    _isPaused = *isPaused;
    u16 const currentFrame = _bus->ppu.GetFrame();
    while ( currentFrame == _bus->ppu.GetFrame() ) {
        if ( _isPaused ) {
            break;
        }
        DecodeExecute();
    }
}
```

`GetFrame` returned a 64 bit int, while `currentFrame` was only 16 bits. Once the number of frames overflowed, the while loop was getting skipped because it wrapped to zero.
