### PR TITLE
UI Refactor

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -26,6 +26,7 @@ Checks: >
   ,-cppcoreguidelines-avoid-c-arrays
   ,-modernize-avoid-c-arrays
   ,-cppcoreguidelines-pro-bounds-pointer-arithmetic
+  ,-cppcoreguidelines-macro-usage
 CheckOptions:
   # Standardized naming conventions:
   - key: readability-identifier-naming.ClassCase

--- a/core/cpu.cpp
+++ b/core/cpu.cpp
@@ -729,17 +729,6 @@ void CPU::DecodeExecute()
     }
 }
 
-void CPU::ExecuteFrame( bool *isPaused ) // NOLINT
-{
-    _isPaused = *isPaused;
-    u64 const currentFrame = _bus->ppu.GetFrame();
-    while ( currentFrame == _bus->ppu.GetFrame() ) {
-        if ( _isPaused ) {
-            break;
-        }
-        DecodeExecute();
-    }
-}
 /*
 ################################################################
 ||                                                            ||

--- a/frontend/include/custom-components.h
+++ b/frontend/include/custom-components.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <cmath>
+#include <functional>
 #include <imgui.h>
 
 /*
@@ -11,16 +13,21 @@
 
 inline ImU32 contrastColor( ImU32 color )
 {
+    /*
+      @brief: Returns a contrasting color based on the input color.
+    */
     ImVec4 const bgColorVec = ImGui::ColorConvertU32ToFloat4( color );
     float const luminance = ( 0.299f * bgColorVec.x ) + ( 0.587f * bgColorVec.y ) + ( 0.114f * bgColorVec.z );
     return luminance > 0.5f ? IM_COL32_BLACK : IM_COL32_WHITE;
 }
 
-inline void selectableColor( ImU32 color )
+inline ImU32 contrastColor( ImVec4 color )
 {
-    ImVec2 const pMin = ImGui::GetItemRectMin();
-    ImVec2 const pMax = ImGui::GetItemRectMax();
-    ImGui::GetWindowDrawList()->AddRectFilled( pMin, pMax, color );
+    /*
+      @brief: Returns a contrasting color based on the input color.
+    */
+    float const luminance = ( 0.299f * color.x ) + ( 0.587f * color.y ) + ( 0.114f * color.z );
+    return luminance > 0.5f ? IM_COL32_BLACK : IM_COL32_WHITE;
 }
 
 /*
@@ -33,101 +40,116 @@ inline void selectableColor( ImU32 color )
 
 namespace CustomComponents
 {
-inline bool selectable( const char *label, bool *pSelected, ImU32 bgColor, ImGuiSelectableFlags flags,
-                        const ImVec2 &sizeArg )
+// clang-format off
+inline bool selectable(
+    const char *label, 
+    int cellIdx, 
+    const ImVec2 cellSize, 
+    int &cellSelected, 
+    int &cellHovered,
+    ImVec4 bgColor = ImVec4( 0.4f, 0.6f, 0.9f, 0.3f ), 
+    ImVec4 hoverColor = ImVec4( 0.4f, 0.6f, 0.9f, 0.7f ),
+    ImVec4 mouseDownColor = ImVec4( 0.4f, 0.6f, 0.9f, 0.5f ), 
+    const std::function<void()> &onHover = []() {},
+    const std::function<void()> &onClick = []() {} )
 {
-    /* @brief ImGui::Selectable wrapper that allows bgColor and label color control
+    // clang-format on
+
+    /*
+      @brief: Custom selectable component that allows for custom styling and callbacks.
+
+      @details: This component wraps ImGui::Button. There is a native ImGui::Selectable, but its customization
+      is limited. This component is intended to be used in grid-like layouts, where a give cell can be
+      selected and hovered.
+
+      @param label: Label to display. Pass nullptr to not display a label.
+      @param cellIdx: Unique value for a given cell.
+      @param cellSize: Size of the cell.
+      @param cellSelected: Reference to the currently selected cell.
+      @param cellHovered: Reference to the currently hovered cell.
+      @param bgColor: Background color. Set to transparent to not display a background.
+      @param hoverColor: Hover color
+      @param mouseDownColor: Mouse down color
+      @param onHover: Default behavior sets the cellHovered value. Additional callback can be passed, which
+      does not override the hover behavior
+      @param onClick: Default behavior sets the cellSelected value. Additional callback can be passed, which
+      does not override the click behavior
+
+      @return: Returns true if the cell was clicked.
+
      */
 
-    ImDrawList *drawList = ImGui::GetWindowDrawList();
-    drawList->ChannelsSplit( 2 );
+    bool const isSelected = ( cellSelected == cellIdx );
+    ImGui::PushID( cellIdx );
 
-    // Channel number is like z-order. Widgets in higher channels are rendered above widgets in lower
-    // channels.
-    drawList->ChannelsSetCurrent( 1 );
+    // Override styles
+    ImGui::PushStyleColor( ImGuiCol_Button, bgColor );
+    ImGui::PushStyleColor( ImGuiCol_ButtonHovered, hoverColor );
+    ImGui::PushStyleColor( ImGuiCol_ButtonActive, mouseDownColor );
+    ImGui::PushStyleVar( ImGuiStyleVar_ItemSpacing, ImVec2( 0, 0 ) );
 
-    // Disable the default highlight, hover, active
-    ImGui::PushStyleColor( ImGuiCol_Header, bgColor );
-    ImGui::PushStyleColor( ImGuiCol_HeaderHovered, bgColor );
-    ImGui::PushStyleColor( ImGuiCol_HeaderActive, bgColor );
-
-    bool const result = ImGui::Selectable( "", pSelected, flags, sizeArg );
+    bool const clicked = ImGui::Button( "##cell", cellSize );
 
     ImGui::PopStyleColor( 3 );
-
-    // Draw background
-    drawList->ChannelsSetCurrent( 0 );
-    selectableColor( bgColor );
-
-    // Draw border for selected
-    drawList->ChannelsSetCurrent( 1 );
-    if ( *pSelected ) {
-        ImVec2 const pMin = ImGui::GetItemRectMin();
-        ImVec2 const pMax = ImGui::GetItemRectMax();
-        ImU32 const  borderColor = contrastColor( bgColor );
-        drawList->AddRect( pMin, pMax, borderColor, 0.0f, 0.0f, 1.0f );
-    }
-
-    // Draw label
-    ImVec2 const pMin = ImGui::GetItemRectMin();
-    ImVec2 const pMax = ImGui::GetItemRectMax();
-    ImU32 const  textColor = contrastColor( bgColor );
-    ImVec2 const textPos = ImVec2( pMin.x + 4, pMin.y + 2 );
-    drawList->AddText( textPos, textColor, label );
-
-    // Commit changes.
-    drawList->ChannelsMerge();
-    return result;
-}
-
-inline bool selectableNoBg( bool *pSelected, ImGuiSelectableFlags flags, const ImVec2 &sizeArg,
-                            const char *label = nullptr )
-{
-    /* @brief ImGui::Selectable wrapper that doesn't draw the background.
-       Can be used as overlay over images or other UI.
-     */
-
-    ImGui::PushStyleVar( ImGuiStyleVar_WindowPadding, ImVec2( 0.0f, 0.0f ) );
-    ImGui::PushStyleVar( ImGuiStyleVar_FramePadding, ImVec2( 0.0f, 0.0f ) );
+    ImGui::PopStyleVar();
 
     ImDrawList *drawList = ImGui::GetWindowDrawList();
-    drawList->ChannelsSplit( 2 );
-    drawList->ChannelsSetCurrent( 1 );
 
-    // Make the selectable background completely transparent.
-    ImGui::PushStyleColor( ImGuiCol_Header, ImVec4( 0, 0, 0, 0 ) );
-    ImGui::PushStyleColor( ImGuiCol_HeaderHovered, ImVec4( 0, 0, 0, 0 ) );
-    ImGui::PushStyleColor( ImGuiCol_HeaderActive, ImVec4( 0, 0, 0, 0 ) );
-
-    bool const result = ImGui::Selectable( "", pSelected, flags, sizeArg );
-
-    ImGui::PopStyleColor( 3 );
-
-    // drawList->ChannelsSetCurrent( 0 );
-    // selectableColor( IM_COL32( 0, 0, 0, 0 ) );
-
-    drawList->ChannelsSetCurrent( 1 );
-    if ( *pSelected ) {
-        ImVec2 const pMin = ImGui::GetItemRectMin();
-        ImVec2 const pMax = ImGui::GetItemRectMax();
-        ImU32 const  borderColor = IM_COL32( 255, 255, 255, 255 );
-        // Draw a faint white fill and a solid black border when selected.
-        drawList->AddRectFilled( pMin, pMax, IM_COL32( 255, 0, 255, 100 ) );
-        drawList->AddRect( pMin, pMax, borderColor, 0.0f, 0, 1.0f );
+    if ( clicked ) {
+        cellSelected = cellIdx;
+        onClick();
     }
 
-    if ( label ) {
+    if ( isSelected ) {
+        float const t = static_cast<float>( ImGui::GetTime() );
+        float const delta = 0.5f + ( 0.5f * sinf( t * 5.0f ) );
+
+        // Get button rect
         ImVec2 const pMin = ImGui::GetItemRectMin();
-        ImU32 const  textColor = IM_COL32( 0, 0, 0, 255 );
-        // Position the label with a slight offset.
+        ImVec2 const pMax = ImGui::GetItemRectMax();
+        // Get a slightly smaller rect
+        ImVec2 const pInnerMin = ImVec2( pMin.x + 2, pMin.y + 2 );
+        ImVec2 const pInnerMax = ImVec2( pMax.x - 2, pMax.y - 2 );
+
+        // Interpolate between two colors, for easier visibility when selected
+        ImVec4 const colorA = ImVec4( 1.0f, 1.0f, 1.0f, 1.0f );
+        ImVec4 const colorB = ImVec4( 0.5f, 0.5f, 0.5f, 1.0f );
+        ImVec4       tweenedColor;
+        tweenedColor.x = colorA.x * ( 1.0f - delta ) + colorB.x * delta;
+        tweenedColor.y = colorA.y * ( 1.0f - delta ) + colorB.y * delta;
+        tweenedColor.z = colorA.z * ( 1.0f - delta ) + colorB.z * delta;
+        tweenedColor.w = colorA.w * ( 1.0f - delta ) + colorB.w * delta;
+        ImU32 const tweenedColor32 =
+            IM_COL32( (int) ( tweenedColor.x * 255 ), (int) ( tweenedColor.y * 255 ),
+                      (int) ( tweenedColor.z * 255 ), (int) ( tweenedColor.w * 255 ) );
+
+        drawList->AddRect( pMin, pMax, IM_COL32( 0, 0, 0, 255 ), 0.0f, 0, 2.0f );
+        drawList->AddRect( pMin, pMax, tweenedColor32, 0.0f, 0, 2.0f );
+        drawList->AddRect( pInnerMin, pInnerMax, IM_COL32( 0, 0, 0, 255 ), 0.0f, 0, 2.0f );
+    }
+
+    if ( ImGui::IsItemHovered( ImGuiHoveredFlags_DelayShort | ImGuiHoveredFlags_NoSharedDelay ) ) {
+        cellHovered = cellIdx;
+        onHover();
+    }
+
+    if ( label != nullptr ) {
+
+        ImVec2 const pMin = ImGui::GetItemRectMin();
+        ImVec2 const pMax = ImGui::GetItemRectMax();
+        ImU32 const  textColor = contrastColor( bgColor );
         ImVec2 const textPos = ImVec2( pMin.x + 4, pMin.y + 2 );
         drawList->AddText( textPos, textColor, label );
     }
 
-    // Pop both style variables.
-    ImGui::PopStyleVar( 2 );
-    drawList->ChannelsMerge();
-    return result;
+    ImGui::PopID();
+
+    return clicked;
+}
+
+inline float getLuminance( ImVec4 color )
+{
+    return ( 0.299f * color.x ) + ( 0.587f * color.y ) + ( 0.114f * color.z );
 }
 
 } // namespace CustomComponents

--- a/frontend/include/renderer.h
+++ b/frontend/include/renderer.h
@@ -76,6 +76,7 @@ class Renderer
     u16  fps = 0;
     u64  frameCount = 0;
 
+    u64 currentFrame = 0;
     std::array<u32, 16384> patternTable0Buffer{};
     std::array<u32, 16384> patternTable1Buffer{};
 
@@ -105,6 +106,7 @@ class Renderer
         bus.ppu.onFrameReady = [this]( const u32 *frameBuffer ) {
             this->ProcessPpuFrameBuffer( frameBuffer );
         };
+        currentFrame = bus.ppu.GetFrame();
     }
 
     bool Setup()
@@ -334,7 +336,7 @@ class Renderer
         while ( running ) {
             u64 const frameStart = SDL_GetPerformanceCounter();
 
-            bus.cpu.ExecuteFrame( &paused );
+            ExecuteFrame();
             PollEvents();
             RenderFrame();
             UpdatePatternTableTextures();
@@ -514,7 +516,18 @@ class Renderer
     #                              #
     ################################
     */
+    void ExecuteFrame()
+    {
+        while ( currentFrame == bus.ppu.GetFrame() ) {
+            if ( paused ) {
+                break;
+            }
+            bus.cpu.DecodeExecute();
+        }
+        currentFrame = bus.ppu.GetFrame();
+    }
 
+    void UpdateUiWindows() {}
     void UpdatePatternTableTextures()
     {
         if ( updatePatternTables ) {

--- a/frontend/include/renderer.h
+++ b/frontend/include/renderer.h
@@ -76,7 +76,7 @@ class Renderer
     u16  fps = 0;
     u64  frameCount = 0;
 
-    u64 currentFrame = 0;
+    u64                    currentFrame = 0;
     std::array<u32, 16384> patternTable0Buffer{};
     std::array<u32, 16384> patternTable1Buffer{};
 

--- a/frontend/ui/palettes.h
+++ b/frontend/ui/palettes.h
@@ -204,10 +204,6 @@ class PaletteWindow : public UIComponent
             ImGui::Dummy( ImVec2( 0, 0 ) );
             for ( int cell = 0; cell < 4; cell++ ) {
                 ImGui::SameLine( 0.0f, 0.0f );
-                int    cellIdx = rowStart + cell;
-                u16    paletteAddress = 0x3F00 + cellIdx;
-                u8     colorIndex = renderer->bus.ppu.Read( paletteAddress );
-                ImVec4 paletteColor = Rgba32ToImVec4( renderer->bus.ppu.GetMasterPaletteColor( colorIndex ) );
                 char   label[3];
                 snprintf( label, sizeof( label ), "%02X", colorIndex );
 

--- a/frontend/ui/palettes.h
+++ b/frontend/ui/palettes.h
@@ -204,7 +204,12 @@ class PaletteWindow : public UIComponent
             ImGui::Dummy( ImVec2( 0, 0 ) );
             for ( int cell = 0; cell < 4; cell++ ) {
                 ImGui::SameLine( 0.0f, 0.0f );
-                char   label[3];
+                int const    cellIdx = rowStart + cell;
+                u16 const    paletteAddress = 0x3F00 + cellIdx;
+                u8 const     colorIndex = renderer->bus.ppu.Read( paletteAddress );
+                ImVec4 const paletteColor =
+                    Rgba32ToImVec4( renderer->bus.ppu.GetMasterPaletteColor( colorIndex ) );
+                char label[3];
                 snprintf( label, sizeof( label ), "%02X", colorIndex );
 
                 auto onHover = [&]() {
@@ -228,7 +233,8 @@ class PaletteWindow : public UIComponent
 
     static ImVec4 HighlightColor( ImVec4 color, float factor )
     {
-        float luminance = static_cast<float>( 0.299 * color.x + 0.587 * color.y + 0.114 * color.z );
+        float const luminance =
+            static_cast<float>( ( 0.299 * color.x ) + ( 0.587 * color.y ) + ( 0.114 * color.z ) );
 
         // darken or lighten based on luminance
         if ( luminance > 0.5f ) {
@@ -251,7 +257,7 @@ class PaletteWindow : public UIComponent
             ImGui::Dummy( ImVec2( 0, 0 ) );
             for ( int cell = 0; cell < 8; cell++ ) {
                 ImGui::SameLine( 0.0f, 0.0f );
-                int cellIdx = rowStart + cell;
+                int const cellIdx = rowStart + cell;
 
                 auto onHover = [&]() {
                     ImGui::PushStyleVar( ImGuiStyleVar_WindowPadding, ImVec2( 10.0f, 10.0f ) );
@@ -264,7 +270,7 @@ class PaletteWindow : public UIComponent
 
                 char label[3];
                 snprintf( label, sizeof( label ), "%02X", rowStart + cell );
-                ImVec4 paletteColor =
+                ImVec4 const paletteColor =
                     Rgba32ToImVec4( renderer->bus.ppu.GetMasterPaletteColor( rowStart + cell ) );
 
                 // clang-format off
@@ -287,9 +293,9 @@ class PaletteWindow : public UIComponent
 
     static ImVec4 Rgba32ToImVec4( u32 color )
     {
-        float r = static_cast<float>( color & 0xFF ) / 255.0f;
-        float g = static_cast<float>( ( color >> 8 ) & 0xFF ) / 255.0f;
-        float b = static_cast<float>( ( color >> 16 ) & 0xFF ) / 255.0f;
+        float const r = static_cast<float>( color & 0xFF ) / 255.0f;
+        float const g = static_cast<float>( ( color >> 8 ) & 0xFF ) / 255.0f;
+        float const b = static_cast<float>( ( color >> 16 ) & 0xFF ) / 255.0f;
 
         return { r, g, b, 255 };
     }

--- a/frontend/ui/palettes.h
+++ b/frontend/ui/palettes.h
@@ -68,8 +68,10 @@ class PaletteWindow : public UIComponent
         ImGui::EndChild();
         ImGui::PopStyleColor();
     }
+
     void RightPanel()
     {
+        ImGui::BeginChild( "right panel" );
         ImGui::PushFont( renderer->fontMonoBold );
         ImGui::Text( "Properties" );
         ImGui::PopFont();
@@ -178,82 +180,105 @@ class PaletteWindow : public UIComponent
     void RenderTabs()
     {
         ImGuiTabBarFlags const tabBarFlags = ImGuiTabBarFlags_None;
-
         if ( ImGui::BeginTabBar( "PaletteTabs", tabBarFlags ) ) {
 
             if ( ImGui::BeginTabItem( "PPU" ) ) {
                 tabSelected = PPU;
-                ImGui::Dummy( ImVec2( 5, 5 ) );
-                for ( int rowStart = 0; rowStart < 32; rowStart += 4 ) {
-                    ImGui::Dummy( ImVec2( 0, 0 ) );
-                    for ( int cell = 0; cell < 4; cell++ ) {
-                        ImGui::SameLine();
-                        u16 const paletteAddress = 0x3F00 + rowStart + cell;
-                        u8 const  colorIndex = renderer->bus.ppu.Read( paletteAddress );
-                        u32 const paletteColor = renderer->bus.ppu.GetMasterPaletteColor( colorIndex );
-                        char      label[3];
-                        snprintf( label, sizeof( label ), "%02X", colorIndex );
-                        bool isSelected = ppuColorSelected == rowStart + cell;
-                        PaletteBox( rowStart + cell, label, &isSelected, paletteColor );
-                    }
-                }
+                RenderPpuPaletteGrid( ImVec2( 30, 30 ) );
                 ImGui::EndTabItem();
             }
 
             if ( ImGui::BeginTabItem( "System" ) ) {
                 tabSelected = SYSTEM;
-                ImGui::Dummy( ImVec2( 5, 5 ) );
-                for ( int rowStart = 0; rowStart < 64; rowStart += 8 ) {
-                    ImGui::Dummy( ImVec2( 0, 0 ) );
-                    for ( int cell = 0; cell < 8; cell++ ) {
-                        u32 const paletteColor = renderer->bus.ppu.GetMasterPaletteColor( rowStart + cell );
-                        ImGui::SameLine();
-                        char label[3];
-                        snprintf( label, sizeof( label ), "%02X", rowStart + cell );
-                        bool isSelected = systemColorSelected == rowStart + cell;
-                        PaletteBox( rowStart + cell, label, &isSelected, paletteColor );
-                    }
-                }
+                RenderSystemPaletteGrid( ImVec2( 30, 30 ) );
                 ImGui::EndTabItem();
             }
             ImGui::EndTabBar();
         }
     }
 
-    void PaletteBox( int id, const char *label, bool *isSelected, u32 rgba32Color, float hw = 30.0 )
+    void RenderPpuPaletteGrid( ImVec2 cellSize )
     {
-        ImColor const color = Rgba32ToImColor( rgba32Color );
-        ImGui::PushID( id );
-        ImVec2 const size = ImVec2( hw, hw );
+        ImGui::Dummy( ImVec2( 5, 5 ) );
+        for ( int rowStart = 0; rowStart < 32; rowStart += 4 ) {
+            ImGui::Dummy( ImVec2( 0, 0 ) );
+            for ( int cell = 0; cell < 4; cell++ ) {
+                ImGui::SameLine( 0.0f, 0.0f );
+                int    cellIdx = rowStart + cell;
+                u16    paletteAddress = 0x3F00 + cellIdx;
+                u8     colorIndex = renderer->bus.ppu.Read( paletteAddress );
+                ImVec4 paletteColor = Rgba32ToImVec4( renderer->bus.ppu.GetMasterPaletteColor( colorIndex ) );
+                char   label[3];
+                snprintf( label, sizeof( label ), "%02X", colorIndex );
 
-        if ( CustomComponents::selectable( label, isSelected, rgba32Color, ImGuiSelectableFlags_None,
-                                           size ) ) {
-
-            if ( tabSelected == SYSTEM ) {
-                systemColorSelected = id;
-            } else {
-                ppuColorSelected = id;
-                systemColorSelected = renderer->bus.ppu.GetPpuPaletteValue( id );
+                auto onHover = [&]() {
+                    ImGui::PushStyleVar( ImGuiStyleVar_WindowPadding, ImVec2( 10.0f, 10.0f ) );
+                    if ( ImGui::BeginItemTooltip() ) {
+                        PpuProps( cellIdx, 120 );
+                        ImGui::EndTooltip();
+                    }
+                    ImGui::PopStyleVar();
+                };
+                // clang-format off
+                CustomComponents::selectable( label, cellIdx, cellSize, ppuColorSelected, ppuColorHovered,
+                                              paletteColor, 
+                                              HighlightColor( paletteColor, 0.2 ),
+                                              HighlightColor( paletteColor, 0.4 ), 
+                                              onHover );
+                // clang-format on
             }
         }
-        if ( ImGui::IsItemHovered( ImGuiHoveredFlags_DelayShort | ImGuiHoveredFlags_NoSharedDelay ) ) {
-            if ( tabSelected == SYSTEM ) {
-                systemColorHovered = id;
-            } else {
-                ppuColorHovered = id;
-            }
+    }
 
-            if ( ImGui::BeginItemTooltip() ) {
-                if ( tabSelected == SYSTEM ) {
-                    SystemProps( systemColorHovered, 100 );
-                } else {
-                    PpuProps( ppuColorHovered, 100 );
-                }
+    static ImVec4 HighlightColor( ImVec4 color, float factor )
+    {
+        float luminance = static_cast<float>( 0.299 * color.x + 0.587 * color.y + 0.114 * color.z );
 
-                ImGui::EndTooltip();
+        // darken or lighten based on luminance
+        if ( luminance > 0.5f ) {
+            color.x -= factor;
+            color.y -= factor;
+            color.z -= factor;
+        } else {
+            color.x += factor;
+            color.y += factor;
+            color.z += factor;
+        }
+
+        return color;
+    }
+
+    void RenderSystemPaletteGrid( ImVec2 cellSize )
+    {
+        ImGui::Dummy( ImVec2( 5, 5 ) );
+        for ( int rowStart = 0; rowStart < 64; rowStart += 8 ) {
+            ImGui::Dummy( ImVec2( 0, 0 ) );
+            for ( int cell = 0; cell < 8; cell++ ) {
+                ImGui::SameLine( 0.0f, 0.0f );
+                int cellIdx = rowStart + cell;
+
+                auto onHover = [&]() {
+                    ImGui::PushStyleVar( ImGuiStyleVar_WindowPadding, ImVec2( 10.0f, 10.0f ) );
+                    if ( ImGui::BeginItemTooltip() ) {
+                        SystemProps( cellIdx, 120 );
+                        ImGui::EndTooltip();
+                    }
+                    ImGui::PopStyleVar();
+                };
+
+                char label[3];
+                snprintf( label, sizeof( label ), "%02X", rowStart + cell );
+                ImVec4 paletteColor =
+                    Rgba32ToImVec4( renderer->bus.ppu.GetMasterPaletteColor( rowStart + cell ) );
+
+                // clang-format off
+                CustomComponents::selectable( label, cellIdx, cellSize, systemColorSelected, systemColorHovered, 
+                                              paletteColor, 
+                                              HighlightColor( paletteColor, 0.2 ),
+                                              HighlightColor( paletteColor, 0.4 ), 
+                                              onHover );
             }
         }
-        ImGui::PopID();
     }
 
     static ImColor Rgba32ToImColor( u32 color )
@@ -262,6 +287,15 @@ class PaletteWindow : public UIComponent
         int const g = static_cast<int>( color >> 8 ) & 0xFF;
         int const b = static_cast<int>( color >> 16 ) & 0xFF;
         return { r, g, b };
+    }
+
+    static ImVec4 Rgba32ToImVec4( u32 color )
+    {
+        float r = static_cast<float>( color & 0xFF ) / 255.0f;
+        float g = static_cast<float>( ( color >> 8 ) & 0xFF ) / 255.0f;
+        float b = static_cast<float>( ( color >> 16 ) & 0xFF ) / 255.0f;
+
+        return { r, g, b, 255 };
     }
 
     static const char *Rgba32ToHexString( u32 color )

--- a/frontend/ui/pattern-tables.h
+++ b/frontend/ui/pattern-tables.h
@@ -130,7 +130,7 @@ class PatternTablesWindow : public UIComponent
 
         for ( int rowStart = 0; rowStart < 256; rowStart += 16 ) {
             for ( int cellIdx = 0; cellIdx < 16; cellIdx++ ) {
-                int idx = ( rowStart + cellIdx + idOffset ) * 16;
+                int const idx = ( rowStart + cellIdx + idOffset ) * 16;
 
                 auto onHover = [&]() {
                     ImGui::PushStyleVar( ImGuiStyleVar_WindowPadding, ImVec2( 10.0f, 10.0f ) );

--- a/frontend/ui/pattern-tables.h
+++ b/frontend/ui/pattern-tables.h
@@ -2,6 +2,7 @@
 #include "bus.h"
 #include "imgui-spectrum.h"
 #include "ui-component.h"
+#include "custom-components.h"
 #include "renderer.h"
 #include <cstdio>
 #include <cstdint>
@@ -78,13 +79,13 @@ class PatternTablesWindow : public UIComponent
         ImGui::BeginChild( "left panel", panelSize, ImGuiChildFlags_Borders, windowFlags );
 
         ImGui::Text( "Pattern Table 0" );
-        RenderPatternTable( &cellSelected, 0, tilemapSize );
+        RenderPatternTable( 0, tilemapSize );
         ImGui::Separator();
 
         ImGui::Spacing();
 
         ImGui::Text( "Pattern Table 1" );
-        RenderPatternTable( &cellSelected, 1, tilemapSize, 256 );
+        RenderPatternTable( 1, tilemapSize, 256 );
 
         ImGui::EndChild();
         ImGui::PopStyleColor();
@@ -104,7 +105,7 @@ class PatternTablesWindow : public UIComponent
         ImGui::EndChild();
     }
 
-    void RenderPatternTable( int *selectCell, int tableIdx, ImVec2 parentSize, int idOffset = 0 )
+    void RenderPatternTable( int tableIdx, ImVec2 parentSize, int idOffset = 0 )
     {
         ImVec2 const           windowSize = ImVec2( parentSize.x, parentSize.y );
         ImVec2 const           tilesetSize = windowSize;
@@ -129,8 +130,20 @@ class PatternTablesWindow : public UIComponent
 
         for ( int rowStart = 0; rowStart < 256; rowStart += 16 ) {
             for ( int cellIdx = 0; cellIdx < 16; cellIdx++ ) {
-                int const idx = ( rowStart + cellIdx + idOffset ) * 16;
-                GridCell( idx, cellSize, selectCell );
+                int idx = ( rowStart + cellIdx + idOffset ) * 16;
+
+                auto onHover = [&]() {
+                    ImGui::PushStyleVar( ImGuiStyleVar_WindowPadding, ImVec2( 10.0f, 10.0f ) );
+                    if ( ImGui::BeginItemTooltip() ) {
+                        PatternTableProps( cellIdx, 120 );
+                        ImGui::EndTooltip();
+                    }
+                    ImGui::PopStyleVar();
+                };
+
+                CustomComponents::selectable( nullptr, idx, cellSize, cellSelected, cellHovered,
+                                              ImVec4( 0, 0, 0, 0 ), ImVec4( 0.4f, 0.6f, 0.9f, 0.5f ),
+                                              ImVec4( 0.4f, 0.6f, 0.9f, 0.7f ), onHover );
                 if ( cellIdx < 15 ) {
                     ImGui::SameLine( 0.0f, 0.0f );
                 }

--- a/frontend/ui/register-viewer.h
+++ b/frontend/ui/register-viewer.h
@@ -1,8 +1,10 @@
 #pragma once
+#include "bus.h"
 #include "ui-component.h"
 #include "renderer.h"
 #include <imgui.h>
 #include "log.h"
+#include <inttypes.h>
 
 class RegisterViewerWindow : public UIComponent
 {
@@ -33,7 +35,7 @@ class RegisterViewerWindow : public UIComponent
     {
         constexpr ImGuiWindowFlags windowFlags = ImGuiWindowFlags_NoResize | ImGuiWindowFlags_MenuBar;
         ImGui::PushStyleVar( ImGuiStyleVar_WindowPadding, ImVec2( 10.0f, 10.0f ) );
-        ImGui::SetNextWindowSizeConstraints( ImVec2( 300, 400 ), ImVec2( 400, 500 ) );
+        ImGui::SetNextWindowSizeConstraints( ImVec2( 300, 420 ), ImVec2( 400, 500 ) );
 
         if ( ImGui::Begin( "Register Viewer", &visible, windowFlags ) ) {
             RenderMenuBar();
@@ -99,16 +101,10 @@ class RegisterViewerWindow : public UIComponent
     void CpuRegisters()
     {
         ImGui::PushStyleColor( ImGuiCol_ChildBg, ImVec4( 1.0f, 1.0f, 1.0f, 1.0f ) );
-        ImGui::BeginChild( "registers", ImVec2( 0, 150 ), ImGuiChildFlags_Borders );
-        ImGui::PushFont( renderer->fontMonoBold );
-        ImGui::Text( "Cycle: " );
-        ImGui::PopFont();
-        ImGui::SameLine();
-        ImGui::Text( U64_FORMAT_SPECIFIER, cpu.GetCycles() );
-        ImGui::Spacing();
+        ImGui::BeginChild( "registers", ImVec2( 0, 160 ), ImGuiChildFlags_Borders );
 
-        float innerSpacing = 25.0f;
-        float outerSpacing = 45.0f;
+        float const innerSpacing = 25.0f;
+        float const outerSpacing = 45.0f;
 
         // display the registers types accordingly
         ImGui::BeginGroup();
@@ -168,6 +164,45 @@ class RegisterViewerWindow : public UIComponent
         ImGui::Text( "%02X", cpu.GetStatusRegister() );
         ImGui::EndGroup();
 
+        ImGui::Dummy( ImVec2( 10, 10 ) );
+        ImGui::Separator();
+
+        ImGui::BeginGroup();
+        ImGui::PushFont( renderer->fontMonoBold );
+        ImGui::Text( "CPU Cycle: " );
+        ImGui::PopFont();
+        ImGui::SameLine();
+        ImGui::Indent( 100 );
+        ImGui::Text( U64_FORMAT_SPECIFIER, cpu.GetCycles() );
+        ImGui::EndGroup();
+
+        ImGui::BeginGroup();
+        ImGui::PushFont( renderer->fontMonoBold );
+        ImGui::Text( "PPU Cycle: " );
+        ImGui::PopFont();
+        ImGui::SameLine();
+        ImGui::Indent( 100 );
+        ImGui::Text( "%" PRIu16, renderer->bus.ppu.GetCycles() );
+        ImGui::EndGroup();
+
+        ImGui::BeginGroup();
+        ImGui::PushFont( renderer->fontMonoBold );
+        ImGui::Text( "Scanline:" );
+        ImGui::PopFont();
+        ImGui::SameLine();
+        ImGui::Indent( 100 );
+        ImGui::Text( "%" PRId16, renderer->bus.ppu.GetScanline() );
+        ImGui::EndGroup();
+
+        ImGui::BeginGroup();
+        ImGui::PushFont( renderer->fontMonoBold );
+        ImGui::Text( "Frame:" );
+        ImGui::PopFont();
+        ImGui::SameLine();
+        ImGui::Indent( 100 );
+        ImGui::Text( "%" PRIu64, renderer->bus.ppu.GetFrame() );
+        ImGui::EndGroup();
+
         ImGui::PopStyleColor();
         ImGui::EndChild();
     }
@@ -190,7 +225,7 @@ class RegisterViewerWindow : public UIComponent
         bool overflowBool = ( status & CPU::Status::Overflow ) != 0;
         bool negativeBool = ( status & CPU::Status::Negative ) != 0;
 
-        float statusSpacing = 140.0f;
+        float const statusSpacing = 140.0f;
 
         // status check boxes
         ImGui::BeginGroup();

--- a/include/cpu.h
+++ b/include/cpu.h
@@ -65,7 +65,6 @@ class CPU
     void WriteAndTick( u16 address, u8 data );
     void NMI();
     void IRQ();
-    void ExecuteFrame( bool *isPaused );
 
     /*
     ################################

--- a/include/cpu.h
+++ b/include/cpu.h
@@ -91,6 +91,22 @@ class CPU
     }
     void ClearTracelog() { _traceLog.clear(); }
 
+    /*
+    ################################
+    ||      Global Variables      ||
+    ################################
+    */
+    enum Status : u8 {
+        Carry = 1 << 0,            // 0b00000001
+        Zero = 1 << 1,             // 0b00000010
+        InterruptDisable = 1 << 2, // 0b00000100
+        Decimal = 1 << 3,          // 0b00001000
+        Break = 1 << 4,            // 0b00010000
+        Unused = 1 << 5,           // 0b00100000
+        Overflow = 1 << 6,         // 0b01000000
+        Negative = 1 << 7,         // 0b10000000
+    };
+
   private:
     friend class CPUTestFixture; // Sometimes used for testing private methods
 
@@ -109,7 +125,7 @@ class CPU
 
     /*
     ################################
-    ||      Global Variables      ||
+    ||  Private Global Variables  ||
     ################################
     */
     bool        _didVblank = false;
@@ -168,18 +184,6 @@ class CPU
     ||                                                            ||
     ################################################################
     */
-
-    // Enum for Status Register
-    enum Status : u8 {
-        Carry = 1 << 0,            // 0b00000001
-        Zero = 1 << 1,             // 0b00000010
-        InterruptDisable = 1 << 2, // 0b00000100
-        Decimal = 1 << 3,          // 0b00001000
-        Break = 1 << 4,            // 0b00010000
-        Unused = 1 << 5,           // 0b00100000
-        Overflow = 1 << 6,         // 0b01000000
-        Negative = 1 << 7,         // 0b10000000
-    };
 
     // Flag methods
     void SetFlags( u8 flag );


### PR DESCRIPTION
### Added more info to the register viewer
![Screenshot 2025-03-05 at 2 39 37 PM](https://github.com/user-attachments/assets/74920278-1e92-478d-96c6-c27755730a1c)

I also created a reusable selectable component, which is now used for palettes and pattern viewer.

---
The registry viewer can only show scanline -1, and PPU values 0-7 while running. This is because of `ExecuteFrame`, which runs an entire frame worth of cycles before breaking out to update the UI. When using the step debugger, the values are shown correctly.

It's probably better to do a few UI updates mid frame. I'll see if I can fix it when I have time.