### PR TITLE
Nametable Viewer, PPU Viewer, Loading ROMs from UI

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -27,6 +27,7 @@ Checks: >
   ,-modernize-avoid-c-arrays
   ,-cppcoreguidelines-pro-bounds-pointer-arithmetic
   ,-cppcoreguidelines-macro-usage
+  ,-readability-function-cognitive-complexity
 CheckOptions:
   # Standardized naming conventions:
   - key: readability-identifier-naming.ClassCase

--- a/core/cpu.cpp
+++ b/core/cpu.cpp
@@ -414,20 +414,23 @@ std::string CPU::LogLineAtPC( bool verbose ) // NOLINT
 
     // Program counter address
     // i.e. FFFF
-    output += utils::toHex( _pc, 4 ) + ":  ";
+    output += utils::toHex( _pc, 4 ) + " ";
 
-    // Hex instruction
-    // i.e. 4C F5 C5, this is the hex instruction
-    u8 const    bytes = _opcodeTable[Read( _pc )].bytes;
-    std::string hexInstruction;
-    for ( u8 i = 0; i < bytes; i++ ) {
-        hexInstruction += utils::toHex( Read( _pc + i ), 2 ) + ' ';
+    if ( verbose ) {
+        output += " k";
+        // Hex instruction
+        // i.e. 4C F5 C5, this is the hex instruction
+        u8 const    bytes = _opcodeTable[Read( _pc )].bytes;
+        std::string hexInstruction;
+        for ( u8 i = 0; i < bytes; i++ ) {
+            hexInstruction += utils::toHex( Read( _pc + i ), 2 ) + ' ';
+        }
+
+        // formatting, the instruction hex_instruction will be 9 characters long, with space padding to
+        // the right. This makes sure the hex line is the same length for all instructions
+        hexInstruction += std::string( 9 - ( bytes * 3 ), ' ' );
+        output += hexInstruction;
     }
-
-    // formatting, the instruction hex_instruction will be 9 characters long, with space padding to
-    // the right. This makes sure the hex line is the same length for all instructions
-    hexInstruction += std::string( 9 - ( bytes * 3 ), ' ' );
-    output += hexInstruction;
 
     // If name starts with a "*", it is an illegal opcode
     ( name[0] == '*' ) ? output += "*" + name.substr( 1 ) + " " : output += name + " ";
@@ -480,36 +483,38 @@ std::string CPU::LogLineAtPC( bool verbose ) // NOLINT
     }
 
     // Pad the assembly string with spaces, for fixed length
-    output += assemblyStr + std::string( 15 - assemblyStr.size(), ' ' );
+    if ( verbose ) {
+        output += assemblyStr + std::string( 15 - assemblyStr.size(), ' ' );
+    }
 
     // Add more log info
+    std::string registersStr;
+    // Format
+    // a: 00 x: 00 y: 00 s: FD
+    registersStr += "a: " + utils::toHex( _a, 2 ) + " ";
+    registersStr += "x: " + utils::toHex( _x, 2 ) + " ";
+    registersStr += "y: " + utils::toHex( _y, 2 ) + " ";
+    registersStr += "s: " + utils::toHex( _s, 2 ) + " ";
+
+    // status register
+    // Will return a formatted status string
+    // p: hex value, status string (NV-BDIZC). Letter present is flag set, dash is flag unset
+    std::string statusStr;
+    statusStr += "p: " + utils::toHex( _p, 2 ) + " ";
+
+    std::string statusFlags = "NV-BDIZC";
+    std::string statusFlagsLower = "nv--dizc";
+    std::string statusFlagsStr;
+    for ( int i = 7; i >= 0; i-- ) {
+        statusFlagsStr += ( _p & ( 1 << i ) ) != 0 ? statusFlags[7 - i] : statusFlagsLower[7 - i];
+    }
+    statusStr += statusFlagsStr;
+
+    // Combine to the output string
+    output += registersStr + statusStr;
+
+    // Scanline num (V)
     if ( verbose ) {
-        std::string registersStr;
-        // Format
-        // a: 00 x: 00 y: 00 s: FD
-        registersStr += "a: " + utils::toHex( _a, 2 ) + " ";
-        registersStr += "x: " + utils::toHex( _x, 2 ) + " ";
-        registersStr += "y: " + utils::toHex( _y, 2 ) + " ";
-        registersStr += "s: " + utils::toHex( _s, 2 ) + " ";
-
-        // status register
-        // Will return a formatted status string
-        // p: hex value, status string (NV-BDIZC). Letter present is flag set, dash is flag unset
-        std::string statusStr;
-        statusStr += "p: " + utils::toHex( _p, 2 ) + "  ";
-
-        std::string statusFlags = "NV-BDIZC";
-        std::string statusFlagsLower = "nv--dizc";
-        std::string statusFlagsStr;
-        for ( int i = 7; i >= 0; i-- ) {
-            statusFlagsStr += ( _p & ( 1 << i ) ) != 0 ? statusFlags[7 - i] : statusFlagsLower[7 - i];
-        }
-        statusStr += statusFlagsStr;
-
-        // Combine to the output string
-        output += registersStr + statusStr;
-
-        // Scanline num (V)
         std::string const scanlineStr = std::to_string( _bus->ppu.GetScanline() );
         // std::string scanline_str_adjusted = std::string( 4 - scanline_str.size(), ' ' );
         output += "  V: " + scanlineStr;

--- a/core/cpu.cpp
+++ b/core/cpu.cpp
@@ -586,6 +586,15 @@ void CPU::Tick()
     _cycles++;
     _bus->ppu.Tick();
     _bus->ppu.Tick();
+
+    // Match mesen trace log, place logger here.
+    if ( _mesenFormatTraceEnabled && !_didMesenTrace ) {
+        _pc--;
+        AddMesenTracelog( LogLineAtPC( true ) );
+        _pc++;
+        _didMesenTrace = true;
+    }
+
     _bus->ppu.Tick();
 }
 
@@ -692,6 +701,8 @@ void CPU::DecodeExecute()
         AddTraceLog( LogLineAtPC( true ) );
     }
 
+    _didMesenTrace = false;
+
     // Fetch the next opcode and increment the program counter
     u8 const opcode = Fetch();
 
@@ -723,6 +734,7 @@ void CPU::DecodeExecute()
 
         // Reset flags
         _isWriteModify = false;
+        _didMesenTrace = false;
     } else {
         // Houston, we have a problem. No opcode was found.
         std::cerr << "Bad opcode: " << std::hex << static_cast<int>( opcode ) << '\n';

--- a/core/ppu.cpp
+++ b/core/ppu.cpp
@@ -3,6 +3,7 @@
 #include "utils.h"
 #include "cartridge.h" // NOLINT
 #include "mappers/mapper-base.h"
+#include <cstdint>
 #include <exception>
 #include <cstdlib>
 #include <array>
@@ -1067,22 +1068,22 @@ u8 PPU::GetSpritePixel() // NOLINT
 
 u32 PPU::GetOutputPixel( u8 bgPixel, u8 spritePixel, u8 bgPalette, u8 spritePalette ) // NOLINT
 {
-    u8 fgPriority = 0; // TODO: Fetch from sprite
-    u8 pixel = 0x00;
-    u8 palette = 0x00;
+    u8 const fgPriority = 0; // TODO: Fetch from sprite
+    u8       pixel = 0x00;
+    u8       palette = 0x00;
     //
     // (fg_pixel != 0) yields 1 if fg_pixel is nonzero (visible).
     // (bg_pixel == 0) yields 1 if the background is transparent.
     // Their bitwise combination with fg_priority tells us if we should use fg.
-    int mask = -( ( ( bgPixel != 0 ) & ( ( spritePixel == 0 ) | fgPriority ) ) );
+    int const mask = -( ( ( bgPixel != 0 ) & ( ( spritePixel == 0 ) | fgPriority ) ) );
 
     // If mask == -1 (all ones), the foreground values are chosen.
     // If mask == 0, the background values are selected.
     pixel = (uint8_t) ( ( mask & spritePixel ) | ( ( ~mask ) & bgPixel ) );
     palette = (uint8_t) ( ( mask & spritePalette ) | ( ( ~mask ) & bgPalette ) );
 
-    u16 paletteAddr = 0x3F00 + ( palette << 2 ) + pixel;
-    u8  paletteIdx = Read( paletteAddr ) & 0x3F;
+    u16 const paletteAddr = 0x3F00 + ( palette << 2 ) + pixel;
+    u8 const  paletteIdx = Read( paletteAddr ) & 0x3F;
 
     return _nesPaletteRgbValues.at( paletteIdx );
 }

--- a/core/ppu.cpp
+++ b/core/ppu.cpp
@@ -1038,8 +1038,24 @@ u8 PPU::GetSpritePalette() // NOLINT
 
 u8 PPU::GetBgPixel() // NOLINT
 {
-    // TODO: Implement
-    return 0x00;
+    if ( _ppuMask.bit.renderBackground == 0 ) {
+        return 0x00;
+    }
+
+    if ( _ppuMask.bit.renderBackgroundLeft == 0 && _cycle < 9 ) {
+        return 0x00;
+    }
+
+    // Compute a bitmask to select the correct bit for the current pixel,
+    // taking into account the fine x scrolling offset.
+    u16 const mask = 0x8000 >> _fineX;
+    // Extract the background pixel bits:
+    // - The high pattern shifter gives a value of 2 if its bit is set.
+    // - The low pattern shifter gives a value of 1 if its bit is set.
+    // Combining them yields a 2-bit pixel index (0-3).
+    u8 const bgPixel =
+        ( ( _bgShiftPatternHigh & mask ) ? 0b10 : 0 ) | ( ( _bgShiftPatternLow & mask ) ? 0b01 : 0 );
+    return bgPixel;
 }
 
 u8 PPU::GetSpritePixel() // NOLINT
@@ -1051,10 +1067,30 @@ u8 PPU::GetSpritePixel() // NOLINT
 
 u32 PPU::GetOutputPixel( u8 bgPixel, u8 spritePixel, u8 bgPalette, u8 spritePalette ) // NOLINT
 {
-    // TODO: Implement
-    (void) bgPixel;
-    (void) spritePixel;
-    (void) bgPalette;
-    (void) spritePalette;
-    return _nesPaletteRgbValues[0x22];
+    u8 fgPriority = 0; // TODO: Fetch from sprite
+    u8 pixel = 0x00;
+    u8 palette = 0x00;
+    //
+    // (fg_pixel != 0) yields 1 if fg_pixel is nonzero (visible).
+    // (bg_pixel == 0) yields 1 if the background is transparent.
+    // Their bitwise combination with fg_priority tells us if we should use fg.
+    int mask = -( ( ( bgPixel != 0 ) & ( ( spritePixel == 0 ) | fgPriority ) ) );
+
+    // If mask == -1 (all ones), the foreground values are chosen.
+    // If mask == 0, the background values are selected.
+    pixel = (uint8_t) ( ( mask & spritePixel ) | ( ( ~mask ) & bgPixel ) );
+    palette = (uint8_t) ( ( mask & spritePalette ) | ( ( ~mask ) & bgPalette ) );
+
+    u16 paletteAddr = 0x3F00 + ( palette << 2 ) + pixel;
+    u8  paletteIdx = Read( paletteAddr ) & 0x3F;
+
+    return _nesPaletteRgbValues.at( paletteIdx );
+}
+
+MirrorMode PPU::GetMirrorMode() const
+{
+    if ( _bus == nullptr ) {
+        return MirrorMode::Vertical;
+    }
+    return _bus->cartridge->GetMirrorMode();
 }

--- a/frontend/include/renderer.h
+++ b/frontend/include/renderer.h
@@ -92,6 +92,19 @@ class Renderer
     std::array<u32, 61440> nametable2Buffer{};
     std::array<u32, 61440> nametable3Buffer{};
 
+    std::array<std::string, 4> testRoms = {
+        "tests/roms/palette.nes",
+        "tests/roms/color_test.nes",
+        "tests/roms/nestest.nes",
+        "tests/roms/mario.nes",
+    };
+    enum RomSelected : u8 {
+        PALETTE,
+        COLOR_TEST,
+        NESTEST,
+        MARIO,
+    };
+
     /*
     ################################
     #          peripherals         #
@@ -112,13 +125,23 @@ class Renderer
 
     void InitEmulator()
     {
-        auto cartridge = std::make_shared<Cartridge>( "tests/roms/palette.nes" );
+        auto romFile = testRoms[RomSelected::PALETTE];
+        auto cartridge = std::make_shared<Cartridge>( romFile );
         bus.LoadCartridge( cartridge );
         bus.cpu.Reset();
         bus.ppu.onFrameReady = [this]( const u32 *frameBuffer ) {
             this->ProcessPpuFrameBuffer( frameBuffer );
         };
         currentFrame = bus.ppu.GetFrame();
+    }
+
+    void LoadNewCartridge( const std::string &newRomFile )
+    {
+        auto newCartridge = std::make_shared<Cartridge>( newRomFile );
+        bus.LoadCartridge( newCartridge );
+        bus.DebugReset();
+        currentFrame = bus.ppu.GetFrame();
+        frameCount = 0;
     }
 
     bool Setup()

--- a/frontend/include/renderer.h
+++ b/frontend/include/renderer.h
@@ -25,6 +25,7 @@
 #include <string>
 #include <memory>
 #include "theme.h"
+#include "chrono"
 
 using u32 = uint32_t;
 using u64 = uint64_t;
@@ -61,6 +62,10 @@ class Renderer
     GLuint        emuScreenShaderProgram = 0;
     GLuint        emuScreenVAO = 0;
     GLuint        emuScreenVBO = 0;
+
+    // frame clock
+    using Clock = std::chrono::steady_clock;
+    Clock::time_point frameStart;
 
     // Pattern tables
     GLuint patternTable0Texture = 0;
@@ -348,6 +353,7 @@ class Renderer
         u64          secondStart = SDL_GetPerformanceCounter();
 
         while ( running ) {
+            frameStart = Clock::now();
             u64 const frameStart = SDL_GetPerformanceCounter();
 
             ExecuteFrame();

--- a/frontend/include/ui-component.h
+++ b/frontend/include/ui-component.h
@@ -1,6 +1,7 @@
 #pragma once
 
 // Define the right format specifier for u64 based on the platform
+#include <imgui.h>
 #ifdef __APPLE__
 #define U64_FORMAT_SPECIFIER "%llu"
 #else
@@ -28,6 +29,28 @@ class UIComponent
     void Hide() { visible = false; }
 
     bool visible{};
+
+    enum DebuggerStatus : int {
+        NORMAL,
+        PAUSED,
+        STEPPING,
+        TIMEOUT,
+        RESET,
+    };
+    DebuggerStatus debuggerStatus = NORMAL;
+
+    void DebugControls();
+
+    static void HelpMarker( const char *desc )
+    {
+        ImGui::TextDisabled( "(?)" );
+        if ( ImGui::BeginItemTooltip() ) {
+            ImGui::PushTextWrapPos( ImGui::GetFontSize() * 35.0f );
+            ImGui::TextUnformatted( desc );
+            ImGui::PopTextWrapPos();
+            ImGui::EndTooltip();
+        }
+    }
 
   protected:
     Renderer *renderer;

--- a/frontend/ui-component.cpp
+++ b/frontend/ui-component.cpp
@@ -1,0 +1,159 @@
+#include "ui-component.h"
+#include "renderer.h"
+
+void UIComponent::DebugControls()
+{
+    ImVec2 size = ImVec2( 400, 120 );
+    if ( ImGui::BeginChild( "debug-control", size, ImGuiChildFlags_Border ) ) {
+        bool const isPaused = renderer->paused;
+
+        ImGui::BeginDisabled( !isPaused );
+        ImGui::PushItemWidth( 140 );
+        if ( ImGui::Button( "Continue" ) ) {
+            renderer->paused = false;
+            debuggerStatus = NORMAL;
+        }
+        ImGui::EndDisabled();
+
+        ImGui::SameLine();
+
+        ImGui::BeginDisabled( isPaused );
+        if ( ImGui::Button( "Pause" ) ) {
+            renderer->paused = true;
+            debuggerStatus = PAUSED;
+        }
+        ImGui::EndDisabled();
+
+        ImGui::SameLine();
+
+        if ( ImGui::Button( "Reset" ) ) {
+            debuggerStatus = RESET;
+            renderer->bus.DebugReset();
+        }
+
+        ImGui::SameLine();
+        ImGui::Text( "CPU Cycle: " U64_FORMAT_SPECIFIER, renderer->bus.cpu.GetCycles() );
+        ImGui::PopItemWidth();
+
+        const char *items[] = { "Cycles", "Instructions", "VBlank", "Scanlines", "Frame", "NMI", "IRQ" };
+        static int  i0 = 1;
+        static int  item = 0;
+
+        ImGui::Dummy( ImVec2( 0, 10 ) );
+        ImGui::AlignTextToFramePadding();
+        ImGui::Text( "Step" );
+        ImGui::SameLine();
+        ImGui::PushItemWidth( 120 );
+        ImGui::InputInt( "", &i0 );
+        ImGui::SameLine();
+        ImGui::Combo( " ", &item, items, IM_ARRAYSIZE( items ) );
+        ImGui::SameLine();
+        ImGui::PopItemWidth();
+        if ( ImGui::Button( "Go" ) ) {
+            renderer->paused = true;
+            debuggerStatus = STEPPING;
+
+            using Clock = std::chrono::steady_clock;
+            auto didTimeout = [&]() -> bool {
+                auto const elapsed =
+                    std::chrono::duration<float>( Clock::now() - renderer->frameStart ).count();
+
+                if ( elapsed > 2.0 ) {
+                    debuggerStatus = TIMEOUT;
+                }
+
+                return debuggerStatus == TIMEOUT;
+            };
+
+            switch ( item ) {
+                case 0: { // Cycles
+                    auto const target = renderer->bus.cpu.GetCycles() + i0;
+                    while ( renderer->bus.cpu.GetCycles() < target && !didTimeout() ) {
+                        renderer->bus.cpu.DecodeExecute();
+                    }
+                    break;
+                }
+                case 1: // Instructions
+                    for ( int i = 0; i < i0; i++ ) {
+                        renderer->bus.cpu.DecodeExecute();
+                    }
+                    break;
+                case 2: // VBlank
+                    if ( !renderer->bus.ppu.GetStatusVblank() ) {
+                        while ( !renderer->bus.ppu.GetStatusVblank() ) {
+                            renderer->bus.cpu.DecodeExecute();
+                        }
+                    } else {
+                        while ( renderer->bus.ppu.GetStatusVblank() ) {
+                            renderer->bus.cpu.DecodeExecute();
+                        }
+                        while ( !renderer->bus.ppu.GetStatusVblank() ) {
+                            renderer->bus.cpu.DecodeExecute();
+                        }
+                    }
+                    break;
+                case 3: { // Scanlines
+                    auto const target = renderer->bus.ppu.GetScanline() + i0;
+                    while ( renderer->bus.ppu.GetScanline() < target ) {
+                        renderer->bus.cpu.DecodeExecute();
+                    }
+                    break;
+                }
+                case 4: { // Frame
+                    auto const target = renderer->bus.ppu.GetFrame() + i0;
+                    while ( renderer->bus.ppu.GetFrame() < target ) {
+                        renderer->bus.cpu.DecodeExecute();
+                    }
+                    break;
+                }
+                case 5: { // NMI
+                    if ( !renderer->bus.ppu.GetCtrlNmiEnable() ) {
+                        while ( !renderer->bus.ppu.GetCtrlNmiEnable() && !didTimeout() ) {
+                            renderer->bus.cpu.DecodeExecute();
+                        }
+                    } else {
+                        while ( renderer->bus.ppu.GetCtrlNmiEnable() && !didTimeout() ) {
+                            renderer->bus.cpu.DecodeExecute();
+                        }
+                        while ( !renderer->bus.ppu.GetCtrlNmiEnable() && !didTimeout() ) {
+                            renderer->bus.cpu.DecodeExecute();
+                        }
+                    }
+                    break;
+                } break;
+                case 6: // IRQ
+                    if ( !renderer->bus.cpu.GetInterruptDisableFlag() ) {
+                        while ( !renderer->bus.cpu.GetInterruptDisableFlag() && !didTimeout() ) {
+                            renderer->bus.cpu.DecodeExecute();
+                        }
+                    } else {
+                        while ( renderer->bus.cpu.GetInterruptDisableFlag() && !didTimeout() ) {
+                            renderer->bus.cpu.DecodeExecute();
+                        }
+                        while ( !renderer->bus.cpu.GetInterruptDisableFlag() && !didTimeout() ) {
+                            renderer->bus.cpu.DecodeExecute();
+                        }
+                    }
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        ImGui::Dummy( ImVec2( 0, 10 ) );
+
+        switch ( debuggerStatus ) {
+            case TIMEOUT:
+                ImGui::PushStyleColor( ImGuiCol_Text, ImVec4( 1.0f, 0.0f, 0.0f, 1.0f ) );
+                ImGui::Text( "Timed out! Step condition could not be matched." );
+                ImGui::PopStyleColor();
+                break;
+
+            default:
+                ImGui::Text( "" );
+                break;
+        }
+
+        ImGui::EndChild();
+    }
+}

--- a/frontend/ui-manager.cpp
+++ b/frontend/ui-manager.cpp
@@ -11,7 +11,8 @@
 #include "log.h"
 #include "memory-display.h"
 #include "palettes.h"
-#include "register-viewer.h"
+#include "cpu-viewer.h"
+#include "ppu-viewer.h"
 #include "pattern-tables.h"
 #include "nametable.h"
 
@@ -25,7 +26,8 @@ UIManager::UIManager( Renderer *renderer )
     AddComponent<MemoryDisplayWindow>( renderer );
     AddComponent<PaletteWindow>( renderer );
     AddComponent<PatternTablesWindow>( renderer );
-    AddComponent<RegisterViewerWindow>( renderer );
+    AddComponent<CpuViewerWindow>( renderer );
+    AddComponent<PpuViewerWindow>( renderer );
     AddComponent<NametableWindow>( renderer );
 }
 

--- a/frontend/ui-manager.cpp
+++ b/frontend/ui-manager.cpp
@@ -13,6 +13,7 @@
 #include "palettes.h"
 #include "register-viewer.h"
 #include "pattern-tables.h"
+#include "nametable.h"
 
 UIManager::UIManager( Renderer *renderer )
 {
@@ -25,6 +26,7 @@ UIManager::UIManager( Renderer *renderer )
     AddComponent<PaletteWindow>( renderer );
     AddComponent<PatternTablesWindow>( renderer );
     AddComponent<RegisterViewerWindow>( renderer );
+    AddComponent<NametableWindow>( renderer );
 }
 
 void UIManager::Render()

--- a/frontend/ui/cpu-viewer.h
+++ b/frontend/ui/cpu-viewer.h
@@ -6,11 +6,11 @@
 #include "log.h"
 #include <cinttypes>
 
-class RegisterViewerWindow : public UIComponent
+class CpuViewerWindow : public UIComponent
 {
   public:
     CPU &cpu; // NOLINT
-    RegisterViewerWindow( Renderer *renderer ) : UIComponent( renderer ), cpu( renderer->bus.cpu )
+    CpuViewerWindow( Renderer *renderer ) : UIComponent( renderer ), cpu( renderer->bus.cpu )
     {
         visible = false;
     }
@@ -20,8 +20,6 @@ class RegisterViewerWindow : public UIComponent
     #           Variables          #
     ################################
     */
-    enum TabType : int { CPU, PPU };
-    int tabSelected = CPU;
 
     /*
     ################################
@@ -37,30 +35,14 @@ class RegisterViewerWindow : public UIComponent
         ImGui::PushStyleVar( ImGuiStyleVar_WindowPadding, ImVec2( 10.0f, 10.0f ) );
         ImGui::SetNextWindowSizeConstraints( ImVec2( 300, 420 ), ImVec2( 400, 500 ) );
 
-        if ( ImGui::Begin( "Register Viewer", &visible, windowFlags ) ) {
+        if ( ImGui::Begin( "CPU Viewer", &visible, windowFlags ) ) {
             RenderMenuBar();
             DebugControls();
             ImGui::Spacing();
             ImGui::PushFont( renderer->fontMono );
 
-            ImGuiTabBarFlags const tabBarFlags = ImGuiTabBarFlags_None;
-            if ( ImGui::BeginTabBar( "Register Tabs", tabBarFlags ) ) {
-
-                if ( ImGui::BeginTabItem( "CPU" ) ) {
-                    tabSelected = CPU;
-                    CpuRegisters();
-                    CpuStatus();
-                    ImGui::EndTabItem();
-                }
-
-                if ( ImGui::BeginTabItem( "PPU" ) ) {
-                    tabSelected = PPU;
-
-                    // TODO: Implement PPU status viewer
-                    ImGui::EndTabItem();
-                }
-                ImGui::EndTabBar();
-            }
+            CpuRegisters();
+            CpuStatus();
 
             ImGui::Spacing();
 

--- a/frontend/ui/cpu-viewer.h
+++ b/frontend/ui/cpu-viewer.h
@@ -3,7 +3,6 @@
 #include "ui-component.h"
 #include "renderer.h"
 #include <imgui.h>
-#include "log.h"
 #include <cinttypes>
 
 class CpuViewerWindow : public UIComponent
@@ -33,7 +32,7 @@ class CpuViewerWindow : public UIComponent
     {
         constexpr ImGuiWindowFlags windowFlags = ImGuiWindowFlags_NoResize | ImGuiWindowFlags_MenuBar;
         ImGui::PushStyleVar( ImGuiStyleVar_WindowPadding, ImVec2( 10.0f, 10.0f ) );
-        ImGui::SetNextWindowSizeConstraints( ImVec2( 300, 420 ), ImVec2( 400, 500 ) );
+        ImGui::SetNextWindowSizeConstraints( ImVec2( 420, 500 ), ImVec2( 420, 500 ) );
 
         if ( ImGui::Begin( "CPU Viewer", &visible, windowFlags ) ) {
             RenderMenuBar();
@@ -50,34 +49,6 @@ class CpuViewerWindow : public UIComponent
         }
         ImGui::End();
         ImGui::PopStyleVar();
-    }
-
-    void DebugControls()
-    {
-        bool const isPaused = renderer->paused;
-
-        ImGui::BeginDisabled( !isPaused );
-        if ( ImGui::Button( "Continue" ) ) {
-            renderer->paused = false;
-        }
-        ImGui::EndDisabled();
-
-        ImGui::SameLine();
-
-        ImGui::BeginDisabled( isPaused );
-        if ( ImGui::Button( "Pause" ) ) {
-            renderer->paused = true;
-        }
-        ImGui::EndDisabled();
-
-        ImGui::SameLine();
-
-        if ( ImGui::Button( "Reset" ) ) {
-            renderer->bus.DebugReset();
-            if ( auto *logWindow = renderer->ui.GetComponent<LogWindow>() ) {
-                logWindow->Clear();
-            }
-        }
     }
 
     void CpuRegisters()

--- a/frontend/ui/debugger.h
+++ b/frontend/ui/debugger.h
@@ -8,7 +8,7 @@
 class DebuggerWindow : public UIComponent
 {
   public:
-    DebuggerWindow( Renderer *renderer ) : UIComponent( renderer ) { visible = true; }
+    DebuggerWindow( Renderer *renderer ) : UIComponent( renderer ) { visible = false; }
 
     void OnVisible() override {}
     void OnHidden() override {}
@@ -27,168 +27,17 @@ class DebuggerWindow : public UIComponent
         ImGuiWindowFlags const windowFlags =
             ImGuiWindowFlags_MenuBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_AlwaysAutoResize;
         ImGui::PushStyleVar( ImGuiStyleVar_WindowPadding, ImVec2( 10.0f, 10.0f ) );
-        ImGui::SetNextWindowSizeConstraints( ImVec2( 300, -1 ), ImVec2( 400, -1 ) );
+        ImGui::SetNextWindowSizeConstraints( ImVec2( 420, -1 ), ImVec2( 420, -1 ) );
 
         if ( ImGui::Begin( "Debugger", &visible, windowFlags ) ) {
             RenderMenuBar();
-            bool const isPaused = renderer->paused;
-
-            ImGui::BeginDisabled( !isPaused );
-            ImGui::PushItemWidth( 140 );
-            if ( ImGui::Button( "Continue" ) ) {
-                renderer->paused = false;
-                debuggerStatus = NORMAL;
-            }
-            ImGui::EndDisabled();
-
-            ImGui::SameLine();
-
-            ImGui::BeginDisabled( isPaused );
-            if ( ImGui::Button( "Pause" ) ) {
-                renderer->paused = true;
-                debuggerStatus = PAUSED;
-            }
-            ImGui::EndDisabled();
-
-            ImGui::SameLine();
-
-            if ( ImGui::Button( "Reset" ) ) {
-                if ( auto *logWindow = renderer->ui.GetComponent<LogWindow>() ) {
-                    logWindow->Clear();
-                }
-                renderer->bus.DebugReset();
-            }
-
-            ImGui::SameLine();
-            ImGui::Text( "CPU Cycle: " U64_FORMAT_SPECIFIER, renderer->bus.cpu.GetCycles() );
-            ImGui::PopItemWidth();
-
-            const char *items[] = { "Cycles", "Instructions", "VBlank", "Scanlines", "Frame", "NMI", "IRQ" };
-            static int  i0 = 1;
-            static int  item = 0;
-
-            ImGui::Dummy( ImVec2( 0, 10 ) );
-            ImGui::AlignTextToFramePadding();
-            ImGui::Text( "Step" );
-            ImGui::SameLine();
-            ImGui::PushItemWidth( 120 );
-            ImGui::InputInt( "", &i0 );
-            ImGui::SameLine();
-            ImGui::Combo( " ", &item, items, IM_ARRAYSIZE( items ) );
-            ImGui::SameLine();
-            ImGui::PopItemWidth();
-            if ( ImGui::Button( "Go" ) ) {
-                renderer->paused = true;
-                debuggerStatus = STEPPING;
-
-                using Clock = std::chrono::steady_clock;
-                auto didTimeout = [&]() -> bool {
-                    auto const elapsed =
-                        std::chrono::duration<float>( Clock::now() - renderer->frameStart ).count();
-
-                    if ( elapsed > 2.0 ) {
-                        debuggerStatus = TIMEOUT;
-                    }
-
-                    return debuggerStatus == TIMEOUT;
-                };
-
-                switch ( item ) {
-                    case 0: { // Cycles
-                        auto const target = renderer->bus.cpu.GetCycles() + i0;
-                        while ( renderer->bus.cpu.GetCycles() < target && !didTimeout() ) {
-                            renderer->bus.cpu.DecodeExecute();
-                        }
-                        break;
-                    }
-                    case 1: // Instructions
-                        for ( int i = 0; i < i0; i++ ) {
-                            renderer->bus.cpu.DecodeExecute();
-                        }
-                        break;
-                    case 2: // VBlank
-                        if ( !renderer->bus.ppu.GetStatusVblank() ) {
-                            while ( !renderer->bus.ppu.GetStatusVblank() ) {
-                                renderer->bus.cpu.DecodeExecute();
-                            }
-                        } else {
-                            while ( renderer->bus.ppu.GetStatusVblank() ) {
-                                renderer->bus.cpu.DecodeExecute();
-                            }
-                            while ( !renderer->bus.ppu.GetStatusVblank() ) {
-                                renderer->bus.cpu.DecodeExecute();
-                            }
-                        }
-                        break;
-                    case 3: { // Scanlines
-                        auto const target = renderer->bus.ppu.GetScanline() + i0;
-                        while ( renderer->bus.ppu.GetScanline() < target ) {
-                            renderer->bus.cpu.DecodeExecute();
-                        }
-                        break;
-                    }
-                    case 4: { // Frame
-                        auto const target = renderer->bus.ppu.GetFrame() + i0;
-                        while ( renderer->bus.ppu.GetFrame() < target ) {
-                            renderer->bus.cpu.DecodeExecute();
-                        }
-                        break;
-                    }
-                    case 5: { // NMI
-                        if ( !renderer->bus.ppu.GetCtrlNmiEnable() ) {
-                            while ( !renderer->bus.ppu.GetCtrlNmiEnable() && !didTimeout() ) {
-                                renderer->bus.cpu.DecodeExecute();
-                            }
-                        } else {
-                            while ( renderer->bus.ppu.GetCtrlNmiEnable() && !didTimeout() ) {
-                                renderer->bus.cpu.DecodeExecute();
-                            }
-                            while ( !renderer->bus.ppu.GetCtrlNmiEnable() && !didTimeout() ) {
-                                renderer->bus.cpu.DecodeExecute();
-                            }
-                        }
-                        break;
-                    } break;
-                    case 6: // IRQ
-                        if ( !renderer->bus.cpu.GetInterruptDisableFlag() ) {
-                            while ( !renderer->bus.cpu.GetInterruptDisableFlag() && !didTimeout() ) {
-                                renderer->bus.cpu.DecodeExecute();
-                            }
-                        } else {
-                            while ( renderer->bus.cpu.GetInterruptDisableFlag() && !didTimeout() ) {
-                                renderer->bus.cpu.DecodeExecute();
-                            }
-                            while ( !renderer->bus.cpu.GetInterruptDisableFlag() && !didTimeout() ) {
-                                renderer->bus.cpu.DecodeExecute();
-                            }
-                        }
-                        break;
-                    default:
-                        break;
-                }
-            }
-
-            ImGui::Dummy( ImVec2( 0, 10 ) );
-
-            switch ( debuggerStatus ) {
-                case TIMEOUT:
-                    ImGui::PushStyleColor( ImGuiCol_Text, ImVec4( 1.0f, 0.0f, 0.0f, 1.0f ) );
-                    ImGui::Text( "Timed out! Step condition could not be matched." );
-                    ImGui::PopStyleColor();
-                    break;
-
-                default:
-                    ImGui::Text( "" );
-                    break;
-            }
+            DebugControls(); // Defined in ui-component.cpp
         }
         ImGui::End();
         ImGui::PopStyleVar();
     }
 
   private:
-    bool _cycleBreakpoint = false;
-
     void RenderMenuBar()
     {
         if ( ImGui::BeginMenuBar() ) {

--- a/frontend/ui/debugger.h
+++ b/frontend/ui/debugger.h
@@ -27,7 +27,7 @@ class DebuggerWindow : public UIComponent
         ImGuiWindowFlags const windowFlags =
             ImGuiWindowFlags_MenuBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_AlwaysAutoResize;
         ImGui::PushStyleVar( ImGuiStyleVar_WindowPadding, ImVec2( 10.0f, 10.0f ) );
-        ImGui::SetNextWindowSizeConstraints( ImVec2( 420, -1 ), ImVec2( 420, -1 ) );
+        ImGui::SetNextWindowSizeConstraints( ImVec2( 430, -1 ), ImVec2( 600, -1 ) );
 
         if ( ImGui::Begin( "Debugger", &visible, windowFlags ) ) {
             RenderMenuBar();

--- a/frontend/ui/log.h
+++ b/frontend/ui/log.h
@@ -53,8 +53,8 @@ class LogWindow : public UIComponent // NOLINT
             ImGui::Combo( "Log Type", &usingLogType, logTypes.data(), (int) logTypes.size() );
             ImGui::PopItemWidth();
             ImGui::SameLine();
-            HelpMarker( "Normal: Logs at the beginning of instruction. \nMesen: Logs each CPU cycle, between "
-                        "PPU cycle 2 and 3." );
+            HelpMarker( "Normal: Logs at the beginning of instruction. \nMesen: Logs between PPU cycle 2 and "
+                        "3 of each instruction." );
             ImGui::Dummy( ImVec2( 0, 10 ) );
 
             // Grab the trace log as long as not on the same cycle.

--- a/frontend/ui/log.h
+++ b/frontend/ui/log.h
@@ -12,7 +12,7 @@ class LogWindow : public UIComponent // NOLINT
 {
   public:
     uint64_t lastCpuCycleLogged = 0;
-    LogWindow( Renderer *renderer ) : UIComponent( renderer ) { visible = true; }
+    LogWindow( Renderer *renderer ) : UIComponent( renderer ) { visible = false; }
 
     void OnVisible() override
     {

--- a/frontend/ui/log.h
+++ b/frontend/ui/log.h
@@ -2,7 +2,6 @@
 #include "ui-component.h"
 #include "renderer.h"
 #include <cstdint>
-#include <cstdarg>
 #include <imgui.h>
 
 #include <algorithm>
@@ -13,32 +12,65 @@ class LogWindow : public UIComponent // NOLINT
 {
   public:
     uint64_t lastCpuCycleLogged = 0;
-    LogWindow( Renderer *renderer ) : UIComponent( renderer ) { visible = false; }
+    LogWindow( Renderer *renderer ) : UIComponent( renderer ) { visible = true; }
 
-    void OnVisible() override { renderer->bus.cpu.EnableTracelog(); }
-    void OnHidden() override { renderer->bus.cpu.DisableTracelog(); }
+    void OnVisible() override
+    {
+        renderer->bus.cpu.EnableTracelog();
+        renderer->bus.cpu.EnableMesenFormatTraceLog();
+    }
+    void OnHidden() override
+    {
+        renderer->bus.cpu.DisableTracelog();
+        renderer->bus.cpu.DisableMesenFormatTraceLog();
+    }
+
+    // variables
+    enum LogType : int {
+        NORMAL, // Logs at the beginning of instruction
+        MESEN,  // Matches mesen's output, logs each cpu cycle, between ppu cycle 2 and 3
+    };
+    int                       usingLogType = NORMAL;
+    std::vector<const char *> logTypes = { "Normal", "Mesen" };
+
     void RenderSelf() override // NOLINT
     {
+        if ( debuggerStatus == RESET ) {
+            Clear();
+        }
+
         ImGuiWindowFlags const windowFlags =
             ImGuiWindowFlags_MenuBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_AlwaysAutoResize;
 
         ImGui::PushStyleVar( ImGuiStyleVar_WindowPadding, ImVec2( 10.0f, 10.0f ) );
-        ImGui::SetNextWindowSizeConstraints( ImVec2( 1000, 600 ), ImVec2( 1000, 600 ) );
+        ImGui::SetNextWindowSizeConstraints( ImVec2( 920, 700 ), ImVec2( 920, 700 ) );
         if ( ImGui::Begin( "Trace Log", &visible, windowFlags ) ) {
 
             RenderMenuBar();
             DebugControls();
+            ImGui::Dummy( ImVec2( 0, 10 ) );
+            ImGui::PushItemWidth( 120 );
+            ImGui::Combo( "Log Type", &usingLogType, logTypes.data(), (int) logTypes.size() );
+            ImGui::PopItemWidth();
+            ImGui::SameLine();
+            HelpMarker( "Normal: Logs at the beginning of instruction. \nMesen: Logs each CPU cycle, between "
+                        "PPU cycle 2 and 3." );
+            ImGui::Dummy( ImVec2( 0, 10 ) );
 
             // Grab the trace log as long as not on the same cycle.
             // We can debounce this more if necessary.
             uint64_t const currentCycle = renderer->bus.cpu.GetCycles();
             if ( currentCycle != lastCpuCycleLogged ) {
                 _buf.clear();
+                _mesenBuf.clear();
                 _lineOffsets.clear();
                 _lineOffsets.push_back( 0 );
                 lastCpuCycleLogged = currentCycle;
                 for ( const auto &line : renderer->bus.cpu.GetTracelog() ) {
                     AddLog( line.c_str() );
+                }
+                for ( const auto &line : renderer->bus.cpu.GetMesenFormatTracelog() ) {
+                    AddLogMesen( line.c_str() );
                 }
             }
 
@@ -70,9 +102,8 @@ class LogWindow : public UIComponent // NOLINT
             _filter.Draw( "Filter", -100.0f );
             ImGui::Dummy( ImVec2( 0, 10 ) );
 
-            ImGui::Separator();
-
-            if ( ImGui::BeginChild( "scrolling", ImVec2( 0, 0 ), ImGuiChildFlags_None,
+            ImGui::PushStyleColor( ImGuiCol_ChildBg, ImVec4( 1.0f, 1.0f, 1.0f, 1.0f ) );
+            if ( ImGui::BeginChild( "scrolling", ImVec2( 0, 0 ), ImGuiChildFlags_Border,
                                     ImGuiWindowFlags_HorizontalScrollbar ) ) {
                 if ( clear ) {
                     Clear();
@@ -83,8 +114,16 @@ class LogWindow : public UIComponent // NOLINT
 
                 ImGui::PushStyleVar( ImGuiStyleVar_ItemSpacing, ImVec2( 0, 0 ) );
                 ImGui::PushFont( renderer->fontMono );
-                const char *buf = _buf.begin();
-                const char *bufEnd = _buf.end();
+
+                const char *buf = nullptr;
+                const char *bufEnd = nullptr;
+                if ( usingLogType == NORMAL ) {
+                    buf = _buf.begin();
+                    bufEnd = _buf.end();
+                } else {
+                    buf = _mesenBuf.begin();
+                    bufEnd = _mesenBuf.end();
+                }
 
                 // filter code pulled from imgui_demo, I have no idea how it works
                 if ( _filter.IsActive() ) {
@@ -122,6 +161,7 @@ class LogWindow : public UIComponent // NOLINT
                     ImGui::SetScrollHereY( 1.0f );
                 }
             }
+            ImGui::PopStyleColor();
             ImGui::EndChild();
             ImGui::End();
             ImGui::PopStyleVar();
@@ -131,47 +171,19 @@ class LogWindow : public UIComponent // NOLINT
     void Clear()
     {
         _buf.clear();
+        _mesenBuf.clear();
         _lineOffsets.clear();
         _lineOffsets.push_back( 0 );
-        renderer->bus.cpu.ClearTracelog();
+        renderer->bus.cpu.ClearTraceLog();
+        renderer->bus.cpu.ClearMesenTraceLog();
     }
 
   private:
     ImGuiTextBuffer _buf;
+    ImGuiTextBuffer _mesenBuf;
     ImGuiTextFilter _filter;
     ImVector<int>   _lineOffsets;
     bool            _autoScroll{ true };
-
-    void DebugControls()
-    {
-        // Debug transport controls
-        bool const isPaused = renderer->paused;
-
-        ImGui::BeginDisabled( !isPaused );
-        ImGui::PushItemWidth( 140 );
-        if ( ImGui::Button( "Continue" ) ) {
-            renderer->paused = false;
-        }
-        ImGui::EndDisabled();
-
-        ImGui::SameLine();
-
-        ImGui::BeginDisabled( isPaused );
-        if ( ImGui::Button( "Pause" ) ) {
-            renderer->paused = true;
-        }
-        ImGui::EndDisabled();
-
-        ImGui::SameLine();
-
-        if ( ImGui::Button( "Reset" ) ) {
-            renderer->bus.DebugReset();
-            Clear();
-        }
-
-        ImGui::Separator();
-        ImGui::Dummy( ImVec2( 0, 3 ) );
-    }
 
     void RenderMenuBar()
     {
@@ -194,6 +206,17 @@ class LogWindow : public UIComponent // NOLINT
         // Process new lines or any additional logic
         for ( int const newSize = _buf.size(); oldSize < newSize; oldSize++ ) {
             if ( _buf[oldSize] == '\n' ) {
+                _lineOffsets.push_back( oldSize + 1 );
+            }
+        }
+    }
+
+    void AddLogMesen( const char *str )
+    {
+        int oldSize = _mesenBuf.size();
+        _mesenBuf.append( str );
+        for ( int const newSize = _mesenBuf.size(); oldSize < newSize; oldSize++ ) {
+            if ( _mesenBuf[oldSize] == '\n' ) {
                 _lineOffsets.push_back( oldSize + 1 );
             }
         }

--- a/frontend/ui/main-menubar.h
+++ b/frontend/ui/main-menubar.h
@@ -12,6 +12,7 @@
 #include "palettes.h"
 #include "register-viewer.h"
 #include "pattern-tables.h"
+#include "nametable.h"
 
 class MainMenuBar : public UIComponent
 {
@@ -60,6 +61,10 @@ class MainMenuBar : public UIComponent
 
                 if ( auto *patternTablesWindow = ui->GetComponent<PatternTablesWindow>() ) {
                     ImGui::MenuItem( "Pattern Tables", nullptr, &patternTablesWindow->visible );
+                }
+
+                if ( auto *nametableWindow = ui->GetComponent<NametableWindow>() ) {
+                    ImGui::MenuItem( "Nametables", nullptr, &nametableWindow->visible );
                 }
 
                 ImGui::EndMenu();

--- a/frontend/ui/main-menubar.h
+++ b/frontend/ui/main-menubar.h
@@ -10,7 +10,8 @@
 #include "log.h"
 #include "memory-display.h"
 #include "palettes.h"
-#include "register-viewer.h"
+#include "cpu-viewer.h"
+#include "ppu-viewer.h"
 #include "pattern-tables.h"
 #include "nametable.h"
 
@@ -28,6 +29,17 @@ class MainMenuBar : public UIComponent
     {
         if ( ImGui::BeginMainMenuBar() ) {
             if ( ImGui::BeginMenu( "File" ) ) {
+
+                if ( ImGui::BeginMenu( "Open Recent" ) ) {
+                    auto testRoms = renderer->testRoms;
+                    for ( auto &romPath : testRoms ) {
+                        if ( ImGui::MenuItem( romPath.c_str() ) ) {
+                            renderer->LoadNewCartridge( romPath );
+                        }
+                    }
+                    ImGui::EndMenu();
+                }
+                Separator();
                 if ( ImGui::MenuItem( "Exit" ) ) {
                     renderer->running = false;
                 }
@@ -35,28 +47,29 @@ class MainMenuBar : public UIComponent
             }
             if ( ImGui::BeginMenu( "Debug" ) ) {
 
-                if ( auto *demoWindow = ui->GetComponent<DemoWindow>() ) {
-                    ImGui::MenuItem( "UI Demo", nullptr, &demoWindow->visible );
-                }
-
                 if ( auto *debuggerWindow = ui->GetComponent<DebuggerWindow>() ) {
                     ImGui::MenuItem( "Debugger", nullptr, &debuggerWindow->visible );
-                }
-
-                if ( auto *logWindow = ui->GetComponent<LogWindow>() ) {
-                    ImGui::MenuItem( "Trace Log", nullptr, &logWindow->visible );
                 }
 
                 if ( auto *memoryDisplayWindow = ui->GetComponent<MemoryDisplayWindow>() ) {
                     ImGui::MenuItem( "Memory Display", nullptr, &memoryDisplayWindow->visible );
                 }
 
-                if ( auto *paletteWindow = ui->GetComponent<PaletteWindow>() ) {
-                    ImGui::MenuItem( "Palettes", nullptr, &paletteWindow->visible );
+                if ( auto *logWindow = ui->GetComponent<LogWindow>() ) {
+                    ImGui::MenuItem( "Trace Log", nullptr, &logWindow->visible );
+                }
+                Separator();
+                if ( auto *cpuViewer = ui->GetComponent<CpuViewerWindow>() ) {
+                    ImGui::MenuItem( "CPU", nullptr, &cpuViewer->visible );
                 }
 
-                if ( auto *registerViewer = ui->GetComponent<RegisterViewerWindow>() ) {
-                    ImGui::MenuItem( "Register Viewer", nullptr, &registerViewer->visible );
+                if ( auto *registerViewer = ui->GetComponent<PpuViewerWindow>() ) {
+                    ImGui::MenuItem( "PPU", nullptr, &registerViewer->visible );
+                }
+                Separator();
+
+                if ( auto *paletteWindow = ui->GetComponent<PaletteWindow>() ) {
+                    ImGui::MenuItem( "Palettes", nullptr, &paletteWindow->visible );
                 }
 
                 if ( auto *patternTablesWindow = ui->GetComponent<PatternTablesWindow>() ) {
@@ -74,6 +87,13 @@ class MainMenuBar : public UIComponent
 
             if ( auto *overlayWindow = ui->GetComponent<OverlayWindow>() ) {
                 ImGui::MenuItem( "Enabled", nullptr, &overlayWindow->visible );
+            }
+            ImGui::EndMenu();
+        }
+        if ( ImGui::BeginMenu( "ImGui Demo" ) ) {
+
+            if ( auto *demoWindow = ui->GetComponent<DemoWindow>() ) {
+                ImGui::MenuItem( "Show", nullptr, &demoWindow->visible );
             }
             ImGui::EndMenu();
         }

--- a/frontend/ui/memory-display.h
+++ b/frontend/ui/memory-display.h
@@ -5,15 +5,36 @@
 #include <cstdio>
 #include <imgui.h>
 #include <functional>
-#include "log.h"
 
 class MemoryDisplayWindow : public UIComponent
 {
   public:
-    MemoryDisplayWindow( Renderer *renderer ) : UIComponent( renderer ) { visible = false; }
+    MemoryDisplayWindow( Renderer *renderer ) : UIComponent( renderer ) { visible = true; }
 
     void OnVisible() override {}
     void OnHidden() override {}
+
+    // variables
+    int  cellHovered = -1;
+    int  cellSelected = -1;
+    int  rowHovered = 0;
+    int  columnHovered = 0;
+    bool highlightRow = false;
+    bool highlightCol = false;
+    int  pcLocation = -1;
+
+    enum MemorySpace : int {
+        CPU, // Logs at the beginning of instruction
+        PPU, // Matches mesen's output, logs each cpu cycle, between ppu cycle 2 and 3
+    };
+    int                       memorySpaceSelected = CPU;
+    std::vector<const char *> memorySpaceLabels = { "CPU Memory", "PPU Memory" };
+
+    enum CellType : int {
+        ColumnHeader,
+        RowHeader,
+    };
+
     void RenderSelf() override
     {
         ImGuiWindowFlags const windowFlags =
@@ -25,42 +46,32 @@ class MemoryDisplayWindow : public UIComponent
 
             RenderMenuBar();
             DebugControls();
+            ImGui::Dummy( ImVec2( 0, 5 ) );
 
-            // Add new items here
-            const char *items[] = { "CPU Memory", "PPU Memory" };
+            // PC Location
+            pcLocation = renderer->bus.cpu.GetProgramCounter();
 
-            // Default to CPU Memory parameters
-            static int         itemSelectedIdx = 0;
-            static const char *header = "CPU Memory:";
-            static const char *childName = "CPU Memory";
-            static int         lowerBound = 0;
-            static int         upperBound = 0xFFFF;
-            static int         step = 16;
-            // Use a lambda to capture the renderer instance
+            // Build the ComboBox
+            if ( ImGui::Combo( "Memory Space", &memorySpaceSelected, memorySpaceLabels.data(),
+                               (int) memorySpaceLabels.size() ) ) {
+                cellSelected = -1;
+                cellHovered = -1;
+                highlightRow = false;
+                highlightCol = false;
+            }
+
+            ImGui::Dummy( ImVec2( 0, 5 ) );
+
+            // Assign parameters here for different memory types
+            static int                           lowerBound = 0;
+            static int                           upperBound = 0xFFFF;
+            static int                           step = 16;
             static std::function<uint8_t( int )> readFunc = [&]( int address ) -> uint8_t {
                 return renderer->bus.cpu.Read( address );
             };
 
-            // Build the ComboBox
-            const char *comboPreview = items[itemSelectedIdx];
-            if ( ImGui::BeginCombo( "Memory Type", comboPreview ) ) {
-                for ( int n = 0; n < IM_ARRAYSIZE( items ); n++ ) {
-                    const bool isSelected = ( itemSelectedIdx == n );
-                    if ( ImGui::Selectable( items[n], isSelected ) ) {
-                        itemSelectedIdx = n;
-                    }
-                    if ( isSelected ) {
-                        ImGui::SetItemDefaultFocus();
-                    }
-                }
-                ImGui::EndCombo();
-            }
-
-            // Assign parameters here for different memory types
-            switch ( itemSelectedIdx ) {
-                case 0:
-                    header = "CPU Memory:";
-                    childName = "CPU Memory";
+            switch ( memorySpaceSelected ) {
+                case CPU:
                     lowerBound = 0x0000;
                     upperBound = 0xFFFF;
                     step = 16;
@@ -68,9 +79,7 @@ class MemoryDisplayWindow : public UIComponent
                         return renderer->bus.cpu.Read( address, true );
                     };
                     break;
-                case 1:
-                    header = "PPU Memory:";
-                    childName = "PPU Memory";
+                case PPU:
                     lowerBound = 0x0000;
                     upperBound = 0x3FFF;
                     step = 16;
@@ -81,7 +90,7 @@ class MemoryDisplayWindow : public UIComponent
             }
 
             // Render the table using the above parameters
-            RenderTable( header, childName, lowerBound, upperBound, step, readFunc );
+            RenderTable( lowerBound, upperBound, step, readFunc );
         }
 
         ImGui::End();
@@ -109,37 +118,51 @@ class MemoryDisplayWindow : public UIComponent
      * This function displays a table with memory addresses and their corresponding byte values.
      * The table includes a header, a child window, and columns for each byte.
      *
-     * @param header The header text to display above the table.
-     * @param childName The name of the child window.
      * @param lowerBound The starting address of the memory range to display.
      * @param upperBound The ending address of the memory range to display.
      * @param step The step size between memory addresses.
      * @param readFunc A function that reads a byte from a given memory address.
      */
-    void RenderTable( const char *header, const char *childName, int lowerBound, int upperBound, int step,
+    void RenderTable( int lowerBound, int upperBound, int step,
                       const std::function<uint8_t( int )> &readFunc )
     {
 
-        // TODO: Delete if not desired
-        (void) header;
-        // ImGui::Text( "%s", header );
-
-        ImGui::BeginChild( childName, ImVec2( 0, 300 ), true );
+        const char *childName = memorySpaceLabels[memorySpaceSelected];
+        ImGui::BeginChild( childName, ImVec2( 0, 400 ), true );
 
         // Use ImGui table to enforce column alignment
-        if ( ImGui::BeginTable( "MemoryTable", 17, ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg ) ) {
-            ImGui::TableSetupColumn( "", ImGuiTableColumnFlags_WidthFixed, 40 );
+        static ImGuiTableFlags tableFlags = ImGuiTableFlags_NoPadOuterX | ImGuiTableFlags_NoPadInnerX |
+                                            ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg |
+                                            ImGuiTableFlags_ScrollY;
+        if ( ImGui::BeginTable( "MemoryTable", 17, tableFlags ) ) {
+            // Remove padding between cells
+            ImGui::PushStyleVarY( ImGuiStyleVar_CellPadding, 0.0f );
+            ImGui::TableSetupScrollFreeze( 0, 1 ); // Make top row always visible
 
-            // One column for each byte
-            ImGui::PushFont( renderer->fontMonoBold );
-
-            // Set the background color for the header row
-            for ( int j = 0; j < 16; j++ ) {
-                char colName[4];
-                snprintf( colName, sizeof( colName ), "%02X", j );
-                ImGui::TableSetupColumn( colName, ImGuiTableColumnFlags_WidthFixed, 20 );
+            // Setup header columns, memory only, no labels
+            for ( int j = 0; j < 17; j++ ) {
+                ImGuiTableColumnFlags columnFlags =
+                    ImGuiTableColumnFlags_WidthFixed | ImGuiTableColumnFlags_NoHeaderLabel;
+                if ( j == 0 ) {
+                    ImGui::TableSetupColumn( "##h", columnFlags, 50 );
+                    continue;
+                }
+                ImGui::TableSetupColumn( "##h", columnFlags, 30 );
             }
             ImGui::TableHeadersRow();
+
+            // Push custom content to header columns
+            ImGui::PushFont( renderer->fontMonoBold );
+            for ( int j = 0; j < 17; j++ ) {
+                ImGui::TableSetColumnIndex( j );
+                if ( j == 0 ) {
+                    BorderCell( j - 1, "##topleft", ColumnHeader );
+                    continue;
+                }
+                char label[4];
+                snprintf( label, sizeof( label ), "%02X", j - 1 );
+                BorderCell( j - 1, label, ColumnHeader );
+            }
             ImGui::PopFont();
 
             // Memory display
@@ -149,7 +172,10 @@ class MemoryDisplayWindow : public UIComponent
                 // Address column
                 ImGui::TableSetColumnIndex( 0 );
                 ImGui::PushFont( renderer->fontMonoBold );
-                ImGui::Text( "%04X", i );
+                char label[5];
+                snprintf( label, sizeof( label ), "%04X", i );
+                int borderCellIdx = i >> 4;
+                BorderCell( borderCellIdx, label, RowHeader );
                 ImGui::PopFont();
 
                 // Hex byte columns
@@ -157,17 +183,129 @@ class MemoryDisplayWindow : public UIComponent
                 ImGui::PushStyleColor( ImGuiCol_Text, IM_COL32( 100, 100, 100, 255 ) );
                 for ( int j = 0; j < 16; j++ ) {
                     uint8_t const byte = readFunc( i + j );
-
                     ImGui::TableSetColumnIndex( j + 1 );
-                    ImGui::Text( "%02X", byte );
+                    int cellIdx = i + j;
+                    MemoryCell( cellIdx, byte );
                 }
                 ImGui::PopStyleColor();
                 ImGui::PopFont();
             }
 
+            ImGui::PopStyleVar();
             ImGui::EndTable();
         }
 
         ImGui::EndChild();
+    }
+
+    void MemoryCell( int cellIdx, int byte, ImVec4 bgColor = ImVec4( 0.0f, 0.0f, 0.0f, 0.0f ),
+                     ImVec4 hoverColor = ImVec4( 0.4f, 0.6f, 0.9f, 0.3f ),
+                     ImVec4 mouseDownColor = ImVec4( 0.4f, 0.6f, 0.9f, 0.6f ),
+                     ImVec4 selectedColor = ImVec4( 0.4f, 0.6f, 0.9f, 0.4f ),
+                     ImVec4 pcLocationColor = ImVec4( 0.4f, 0.6f, 0.9f, 0.4f ) )
+
+    {
+
+        ImGui::PushID( cellIdx + 0xFFFF );
+        ImGui::PushStyleColor( ImGuiCol_Button, bgColor );
+        ImGui::PushStyleColor( ImGuiCol_ButtonHovered, hoverColor );
+        ImGui::PushStyleColor( ImGuiCol_ButtonActive, mouseDownColor );
+        int colorPushed = 3;
+        ImGui::PushStyleVar( ImGuiStyleVar_ItemSpacing, ImVec2( 0, 0 ) );
+
+        // Highlight row
+        if ( highlightRow && ( cellIdx >> 4 ) == rowHovered ) {
+            ImGui::PushStyleColor( ImGuiCol_Button, ImVec4( 0.4f, 0.6f, 0.9f, 0.1f ) );
+            colorPushed++;
+        }
+
+        // Highlight column
+        if ( highlightCol && ( cellIdx & 0xF ) == columnHovered ) {
+            ImGui::PushStyleColor( ImGuiCol_Button, ImVec4( 0.4f, 0.6f, 0.9f, 0.1f ) );
+            colorPushed++;
+        }
+
+        // Selected
+        if ( cellSelected == cellIdx ) {
+            ImGui::PushStyleColor( ImGuiCol_Button, selectedColor );
+            colorPushed++;
+        }
+
+        // PC location highlight
+        if ( cellIdx == pcLocation ) {
+            ImGui::PushStyleColor( ImGuiCol_Button, pcLocationColor );
+            colorPushed++;
+        }
+
+        char label[4];
+        snprintf( label, sizeof( label ), "%02X", byte );
+        bool const clicked = ImGui::Button( label, ImVec2( -FLT_MIN, 0.0f ) );
+        ImGui::PopID();
+        ImGui::PopStyleColor( colorPushed );
+        ImGui::PopStyleVar();
+
+        if ( clicked ) {
+            cellSelected = cellIdx;
+        }
+
+        // Hover
+        if ( ImGui::IsItemHovered( ImGuiHoveredFlags_DelayNone | ImGuiHoveredFlags_NoSharedDelay ) ) {
+            cellHovered = cellIdx;
+            rowHovered = cellIdx >> 4;
+            columnHovered = cellIdx & 0xF;
+            highlightRow = true;
+            highlightCol = true;
+            ImGui::PushStyleVar( ImGuiStyleVar_WindowPadding, ImVec2( 10.0f, 10.0f ) );
+            if ( ImGui::BeginItemTooltip() ) {
+                CellProps( cellIdx, byte );
+                ImGui::EndTooltip();
+            }
+            ImGui::PopStyleVar();
+        }
+    }
+
+    void BorderCell( int cellIdx, const char *label, CellType type,
+                     ImVec4 bgColor = ImVec4( 0.0f, 0.0f, 0.0f, 0.0f ),
+                     ImVec4 hoverColor = ImVec4( 0.4f, 0.6f, 0.9f, 0.3f ),
+                     ImVec4 mouseDownColor = ImVec4( 0.4f, 0.6f, 0.9f, 0.6f ) )
+    {
+
+        ImGui::PushStyleColor( ImGuiCol_Button, bgColor );
+        ImGui::PushStyleColor( ImGuiCol_ButtonHovered, hoverColor );
+        ImGui::PushStyleColor( ImGuiCol_ButtonActive, mouseDownColor );
+        ImGui::Button( label, ImVec2( -FLT_MIN, 0.0f ) );
+        if ( ImGui::IsItemHovered( ImGuiHoveredFlags_DelayNone | ImGuiHoveredFlags_NoSharedDelay ) ) {
+            if ( cellIdx >= 0 ) {
+                if ( type == ColumnHeader ) {
+                    columnHovered = cellIdx;
+                    highlightCol = true;
+                    highlightRow = false;
+                } else if ( type == RowHeader ) {
+                    rowHovered = cellIdx;
+                    highlightRow = true;
+                    highlightCol = false;
+                }
+            } else {
+                highlightRow = false;
+                highlightCol = false;
+            }
+        }
+        ImGui::PopStyleColor( 3 );
+    }
+    static void CellProps( int targetId, int byte, float indentSpacing = 70 )
+    {
+        u16 const addr = 0x0000 + targetId;
+        ImGui::BeginGroup();
+
+        ImGui::Text( "Address:" );
+        ImGui::SameLine();
+        ImGui::Indent( indentSpacing );
+        ImGui::Text( "$%04X", addr );
+        ImGui::Unindent( indentSpacing );
+        ImGui::Text( "Value:" );
+        ImGui::SameLine();
+        ImGui::Indent( indentSpacing );
+        ImGui::Text( "$%02X", byte );
+        ImGui::EndGroup();
     }
 };

--- a/frontend/ui/memory-display.h
+++ b/frontend/ui/memory-display.h
@@ -24,35 +24,7 @@ class MemoryDisplayWindow : public UIComponent
         if ( ImGui::Begin( "Memory Viewer", &visible, windowFlags ) ) {
 
             RenderMenuBar();
-            bool const isPaused = renderer->paused;
-
-            ImGui::BeginDisabled( !isPaused );
-            ImGui::PushItemWidth( 140 );
-            if ( ImGui::Button( "Continue" ) ) {
-                renderer->paused = false;
-            }
-            ImGui::EndDisabled();
-
-            ImGui::SameLine();
-
-            ImGui::BeginDisabled( isPaused );
-            if ( ImGui::Button( "Pause" ) ) {
-                renderer->paused = true;
-            }
-            ImGui::EndDisabled();
-
-            ImGui::SameLine();
-
-            if ( ImGui::Button( "Reset" ) ) {
-                renderer->bus.DebugReset();
-                if ( auto *logWindow = renderer->ui.GetComponent<LogWindow>() ) {
-                    logWindow->Clear();
-                }
-            }
-
-            ImGui::SameLine();
-            ImGui::Text( "CPU Cycle: " U64_FORMAT_SPECIFIER, renderer->bus.cpu.GetCycles() );
-            ImGui::PopItemWidth();
+            DebugControls();
 
             // Add new items here
             const char *items[] = { "CPU Memory", "PPU Memory" };

--- a/frontend/ui/nametable.h
+++ b/frontend/ui/nametable.h
@@ -5,12 +5,13 @@
 #include "mappers/mapper-base.h"
 #include "ui-component.h"
 #include "renderer.h"
+#include "log.h"
 #include <imgui.h>
 
 class NametableWindow : public UIComponent
 {
   public:
-    NametableWindow( Renderer *renderer ) : UIComponent( renderer ) { visible = true; }
+    NametableWindow( Renderer *renderer ) : UIComponent( renderer ) { visible = false; }
 
     /*
     ################################
@@ -36,6 +37,7 @@ class NametableWindow : public UIComponent
 
         if ( ImGui::Begin( "Tiles", &visible, windowFlags ) ) {
             RenderMenuBar();
+            DebugControls();
 
             ImGui::PushFont( renderer->fontMono );
             LeftPanel();
@@ -193,5 +195,33 @@ class NametableWindow : public UIComponent
         }
 
         ImGui::EndGroup();
+    }
+
+    void DebugControls()
+    {
+        bool const isPaused = renderer->paused;
+
+        ImGui::BeginDisabled( !isPaused );
+        if ( ImGui::Button( "Continue" ) ) {
+            renderer->paused = false;
+        }
+        ImGui::EndDisabled();
+
+        ImGui::SameLine();
+
+        ImGui::BeginDisabled( isPaused );
+        if ( ImGui::Button( "Pause" ) ) {
+            renderer->paused = true;
+        }
+        ImGui::EndDisabled();
+
+        ImGui::SameLine();
+
+        if ( ImGui::Button( "Reset" ) ) {
+            renderer->bus.DebugReset();
+            if ( auto *logWindow = renderer->ui.GetComponent<LogWindow>() ) {
+                logWindow->Clear();
+            }
+        }
     }
 };

--- a/frontend/ui/nametable.h
+++ b/frontend/ui/nametable.h
@@ -5,7 +5,6 @@
 #include "mappers/mapper-base.h"
 #include "ui-component.h"
 #include "renderer.h"
-#include "log.h"
 #include <imgui.h>
 
 class NametableWindow : public UIComponent
@@ -33,7 +32,7 @@ class NametableWindow : public UIComponent
     {
         ImGuiWindowFlags const windowFlags = ImGuiWindowFlags_MenuBar;
         ImGui::PushStyleVar( ImGuiStyleVar_WindowPadding, ImVec2( 10.0f, 10.0f ) );
-        ImGui::SetNextWindowSizeConstraints( ImVec2( 1000, 700 ), ImVec2( 1000, 800 ) );
+        ImGui::SetNextWindowSizeConstraints( ImVec2( 1000, 820 ), ImVec2( 1000, 820 ) );
 
         if ( ImGui::Begin( "Tiles", &visible, windowFlags ) ) {
             RenderMenuBar();
@@ -195,33 +194,5 @@ class NametableWindow : public UIComponent
         }
 
         ImGui::EndGroup();
-    }
-
-    void DebugControls()
-    {
-        bool const isPaused = renderer->paused;
-
-        ImGui::BeginDisabled( !isPaused );
-        if ( ImGui::Button( "Continue" ) ) {
-            renderer->paused = false;
-        }
-        ImGui::EndDisabled();
-
-        ImGui::SameLine();
-
-        ImGui::BeginDisabled( isPaused );
-        if ( ImGui::Button( "Pause" ) ) {
-            renderer->paused = true;
-        }
-        ImGui::EndDisabled();
-
-        ImGui::SameLine();
-
-        if ( ImGui::Button( "Reset" ) ) {
-            renderer->bus.DebugReset();
-            if ( auto *logWindow = renderer->ui.GetComponent<LogWindow>() ) {
-                logWindow->Clear();
-            }
-        }
     }
 };

--- a/frontend/ui/nametable.h
+++ b/frontend/ui/nametable.h
@@ -1,0 +1,197 @@
+#pragma once
+#include "bus.h"
+#include "custom-components.h"
+#include "imgui-spectrum.h"
+#include "mappers/mapper-base.h"
+#include "ui-component.h"
+#include "renderer.h"
+#include <imgui.h>
+
+class NametableWindow : public UIComponent
+{
+  public:
+    NametableWindow( Renderer *renderer ) : UIComponent( renderer ) { visible = true; }
+
+    /*
+    ################################
+    #           Variables          #
+    ################################
+    */
+    int cellSelected = 0;
+    int cellHovered = 0;
+
+    /*
+    ################################
+    #            Methods           #
+    ################################
+    */
+
+    void OnVisible() override { renderer->updateNametables = true; }
+    void OnHidden() override { renderer->updateNametables = false; }
+    void RenderSelf() override
+    {
+        ImGuiWindowFlags const windowFlags = ImGuiWindowFlags_MenuBar;
+        ImGui::PushStyleVar( ImGuiStyleVar_WindowPadding, ImVec2( 10.0f, 10.0f ) );
+        ImGui::SetNextWindowSizeConstraints( ImVec2( 1000, 700 ), ImVec2( 1000, 800 ) );
+
+        if ( ImGui::Begin( "Tiles", &visible, windowFlags ) ) {
+            RenderMenuBar();
+
+            ImGui::PushFont( renderer->fontMono );
+            LeftPanel();
+            ImGui::SameLine();
+            RightPanel();
+            ImGui::PopFont();
+        }
+        ImGui::End();
+        ImGui::PopStyleVar();
+    }
+    void LeftPanel()
+    {
+        ImVec2 const           panelSize = ImVec2( 660, 620 );
+        ImVec2 const           tilemapSize = ImVec2( 320, 300 );
+        ImGuiWindowFlags const windowFlags =
+            ImGuiWindowFlags_NoScrollWithMouse | ImGuiWindowFlags_NoScrollbar;
+
+        ImGui::PushStyleColor( ImGuiCol_ChildBg, Spectrum::GRAY100 );
+        ImGui::PushStyleVar( ImGuiStyleVar_WindowPadding, ImVec2( 10.0f, 10.0f ) );
+        ImGui::BeginChild( "left panel", panelSize, ImGuiChildFlags_Borders, windowFlags );
+
+        ImGui::PushStyleVar( ImGuiStyleVar_ItemSpacing, ImVec2( 0, 1 ) );
+        RenderNametable( 0, tilemapSize );
+        ImGui::SameLine( 0, 0 );
+        ImGui::Dummy( ImVec2( 1, 0 ) );
+        ImGui::SameLine( 0, 0 );
+        RenderNametable( 1, tilemapSize, 0x0400 );
+        RenderNametable( 2, tilemapSize, 0x0800 );
+        ImGui::SameLine( 0, 0 );
+        ImGui::Dummy( ImVec2( 1, 0 ) );
+        ImGui::SameLine( 0, 0 );
+        RenderNametable( 3, tilemapSize, 0x0C00 );
+        ImGui::PopStyleVar();
+
+        ImGui::EndChild();
+        ImGui::PopStyleColor();
+        ImGui::PopStyleVar();
+    }
+
+    void RightPanel()
+    {
+        ImGui::BeginChild( "right panel", ImVec2( 0, 0 ) );
+
+        ImGui::PushFont( renderer->fontMonoBold );
+        ImGui::Text( "Properties" );
+        ImGui::PopFont();
+        ImGui::Separator();
+        NametableProps( cellSelected, 160 );
+        ImGui::EndChild();
+    }
+
+    void RenderMenuBar()
+    {
+        if ( ImGui::BeginMenuBar() ) {
+            if ( ImGui::BeginMenu( "File" ) ) {
+                if ( ImGui::MenuItem( "Close" ) ) {
+                    visible = false;
+                }
+                ImGui::EndMenu();
+            }
+            ImGui::EndMenuBar();
+        }
+    }
+
+    void RenderNametable( int tableIdx, ImVec2 parentSize, int addrOffset = 0 )
+    {
+        ImVec2 const           windowSize = ImVec2( parentSize.x, parentSize.y );
+        ImVec2 const           tilesetSize = windowSize;
+        ImVec2 const           cellSize = ImVec2( tilesetSize.x / 32, tilesetSize.y / 30 );
+        ImGuiWindowFlags const windowFlags =
+            ImGuiWindowFlags_NoScrollWithMouse | ImGuiWindowFlags_NoScrollbar;
+        ImGui::PushStyleVar( ImGuiStyleVar_WindowPadding, ImVec2( 0.0f, 0.0f ) );
+        char childName[32];
+        snprintf( childName, sizeof( childName ), "PatternTable%d", tableIdx );
+        ImGui::BeginChild( childName, windowSize, 0, windowFlags );
+
+        // Grab texture
+        GLuint const textureHandle = renderer->GrabNametableTextureHandle( tableIdx );
+        ImGui::Image( (ImTextureID) (intptr_t) textureHandle, tilesetSize );
+
+        // Save the current cursor position, for later restoring it.
+        ImVec2 const currentCursorPos = ImGui::GetCursorScreenPos();
+        ImVec2 const gridStartPos = ImGui::GetWindowPos();
+        ImGui::SetCursorScreenPos( gridStartPos );
+
+        ImDrawList *drawList = ImGui::GetWindowDrawList();
+
+        u16 baseTileAddr = 0x2000 + addrOffset;
+
+        for ( int rowStart = 0; rowStart < 960; rowStart += 32 ) {
+            for ( int cellIdx = 0; cellIdx < 32; cellIdx++ ) {
+                int const tileAddr = baseTileAddr + rowStart + cellIdx;
+
+                auto onHover = [&]() {
+                    ImGui::PushStyleVar( ImGuiStyleVar_WindowPadding, ImVec2( 10.0f, 10.0f ) );
+                    if ( ImGui::BeginItemTooltip() ) {
+                        NametableProps( tileAddr, 160 );
+                        ImGui::EndTooltip();
+                    }
+                    ImGui::PopStyleVar();
+                };
+
+                CustomComponents::selectable( nullptr, tileAddr, cellSize, cellSelected, cellHovered,
+                                              ImVec4( 0, 0, 0, 0 ), ImVec4( 0.4f, 0.6f, 0.9f, 0.5f ),
+                                              ImVec4( 0.4f, 0.6f, 0.9f, 0.7f ), onHover );
+                if ( cellIdx < 31 ) {
+                    ImGui::SameLine( 0.0f, 0.0f );
+                }
+            }
+        }
+
+        // restore cursor
+        ImGui::SetCursorScreenPos( currentCursorPos );
+        ImGui::EndChild();
+        ImGui::PopStyleVar();
+    }
+
+    void NametableProps( int targetAddr, float indentSpacing = 140 )
+    {
+        ImGui::BeginGroup();
+
+        ImGui::Text( "Tile Address (PPU)" );
+        ImGui::SameLine();
+        ImGui::Indent( indentSpacing );
+        ImGui::Text( "$%04X", targetAddr );
+
+        ImGui::Unindent( indentSpacing );
+        ImGui::Text( "Tile Index" );
+        ImGui::SameLine();
+        ImGui::Indent( indentSpacing );
+        int tileValue = renderer->bus.ppu.Read( targetAddr );
+        ImGui::Text( "$%02X (%d)", tileValue, tileValue );
+
+        ImGui::Unindent( indentSpacing );
+        ImGui::Text( "Mirroring" );
+        ImGui::SameLine();
+        ImGui::Indent( indentSpacing );
+        MirrorMode const mode = renderer->bus.ppu.GetMirrorMode();
+        switch ( mode ) {
+            case MirrorMode::Horizontal:
+                ImGui::Text( "Horizontal" );
+                break;
+            case MirrorMode::Vertical:
+                ImGui::Text( "Vertical" );
+                break;
+            case MirrorMode::SingleLower:
+                ImGui::Text( "Single Lower" );
+                break;
+            case MirrorMode::SingleUpper:
+                ImGui::Text( "Single Upper" );
+                break;
+            case MirrorMode::FourScreen:
+                ImGui::Text( "Four Screen" );
+                break;
+        }
+
+        ImGui::EndGroup();
+    }
+};

--- a/frontend/ui/nametable.h
+++ b/frontend/ui/nametable.h
@@ -125,7 +125,7 @@ class NametableWindow : public UIComponent
 
         ImDrawList *drawList = ImGui::GetWindowDrawList();
 
-        u16 baseTileAddr = 0x2000 + addrOffset;
+        u16 const baseTileAddr = 0x2000 + addrOffset;
 
         for ( int rowStart = 0; rowStart < 960; rowStart += 32 ) {
             for ( int cellIdx = 0; cellIdx < 32; cellIdx++ ) {
@@ -168,7 +168,7 @@ class NametableWindow : public UIComponent
         ImGui::Text( "Tile Index" );
         ImGui::SameLine();
         ImGui::Indent( indentSpacing );
-        int tileValue = renderer->bus.ppu.Read( targetAddr );
+        int const tileValue = renderer->bus.ppu.Read( targetAddr );
         ImGui::Text( "$%02X (%d)", tileValue, tileValue );
 
         ImGui::Unindent( indentSpacing );

--- a/frontend/ui/palettes.h
+++ b/frontend/ui/palettes.h
@@ -1,7 +1,6 @@
 #pragma once
 #include "bus.h"
 #include "ui-component.h"
-#include "log.h"
 #include "renderer.h"
 #include <cstdio>
 #include <imgui.h>
@@ -40,7 +39,7 @@ class PaletteWindow : public UIComponent
     {
         ImGuiWindowFlags const windowFlags = ImGuiWindowFlags_MenuBar;
         ImGui::PushStyleVar( ImGuiStyleVar_WindowPadding, ImVec2( 10.0f, 10.0f ) );
-        ImGui::SetNextWindowSizeConstraints( ImVec2( 620, 400 ), ImVec2( 1000, 600 ) );
+        ImGui::SetNextWindowSizeConstraints( ImVec2( 620, 500 ), ImVec2( 1000, 600 ) );
 
         if ( ImGui::Begin( "Palettes", &visible, windowFlags ) ) {
             RenderMenuBar();
@@ -323,34 +322,6 @@ class PaletteWindow : public UIComponent
                 ImGui::EndMenu();
             }
             ImGui::EndMenuBar();
-        }
-    }
-
-    void DebugControls()
-    {
-        bool const isPaused = renderer->paused;
-
-        ImGui::BeginDisabled( !isPaused );
-        if ( ImGui::Button( "Continue" ) ) {
-            renderer->paused = false;
-        }
-        ImGui::EndDisabled();
-
-        ImGui::SameLine();
-
-        ImGui::BeginDisabled( isPaused );
-        if ( ImGui::Button( "Pause" ) ) {
-            renderer->paused = true;
-        }
-        ImGui::EndDisabled();
-
-        ImGui::SameLine();
-
-        if ( ImGui::Button( "Reset" ) ) {
-            renderer->bus.DebugReset();
-            if ( auto *logWindow = renderer->ui.GetComponent<LogWindow>() ) {
-                logWindow->Clear();
-            }
         }
     }
 };

--- a/frontend/ui/palettes.h
+++ b/frontend/ui/palettes.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "bus.h"
 #include "ui-component.h"
+#include "log.h"
 #include "renderer.h"
 #include <cstdio>
 #include <imgui.h>
@@ -43,6 +44,7 @@ class PaletteWindow : public UIComponent
 
         if ( ImGui::Begin( "Palettes", &visible, windowFlags ) ) {
             RenderMenuBar();
+            DebugControls();
 
             ImGui::PushFont( renderer->fontMono );
 
@@ -321,6 +323,34 @@ class PaletteWindow : public UIComponent
                 ImGui::EndMenu();
             }
             ImGui::EndMenuBar();
+        }
+    }
+
+    void DebugControls()
+    {
+        bool const isPaused = renderer->paused;
+
+        ImGui::BeginDisabled( !isPaused );
+        if ( ImGui::Button( "Continue" ) ) {
+            renderer->paused = false;
+        }
+        ImGui::EndDisabled();
+
+        ImGui::SameLine();
+
+        ImGui::BeginDisabled( isPaused );
+        if ( ImGui::Button( "Pause" ) ) {
+            renderer->paused = true;
+        }
+        ImGui::EndDisabled();
+
+        ImGui::SameLine();
+
+        if ( ImGui::Button( "Reset" ) ) {
+            renderer->bus.DebugReset();
+            if ( auto *logWindow = renderer->ui.GetComponent<LogWindow>() ) {
+                logWindow->Clear();
+            }
         }
     }
 };

--- a/frontend/ui/pattern-tables.h
+++ b/frontend/ui/pattern-tables.h
@@ -4,7 +4,6 @@
 #include "ui-component.h"
 #include "custom-components.h"
 #include "renderer.h"
-#include "log.h"
 #include <cstdio>
 #include <cstdint>
 #include <cmath>
@@ -40,7 +39,7 @@ class PatternTablesWindow : public UIComponent
     {
         ImGuiWindowFlags const windowFlags = ImGuiWindowFlags_MenuBar;
         ImGui::PushStyleVar( ImGuiStyleVar_WindowPadding, ImVec2( 10.0f, 10.0f ) );
-        ImGui::SetNextWindowSizeConstraints( ImVec2( 400, 700 ), ImVec2( 600, 700 ) );
+        ImGui::SetNextWindowSizeConstraints( ImVec2( 400, 800 ), ImVec2( 600, 800 ) );
 
         if ( ImGui::Begin( "Tiles", &visible, windowFlags ) ) {
             RenderMenuBar();
@@ -324,34 +323,6 @@ class PatternTablesWindow : public UIComponent
                 ImGui::EndMenu();
             }
             ImGui::EndMenuBar();
-        }
-    }
-
-    void DebugControls()
-    {
-        bool const isPaused = renderer->paused;
-
-        ImGui::BeginDisabled( !isPaused );
-        if ( ImGui::Button( "Continue" ) ) {
-            renderer->paused = false;
-        }
-        ImGui::EndDisabled();
-
-        ImGui::SameLine();
-
-        ImGui::BeginDisabled( isPaused );
-        if ( ImGui::Button( "Pause" ) ) {
-            renderer->paused = true;
-        }
-        ImGui::EndDisabled();
-
-        ImGui::SameLine();
-
-        if ( ImGui::Button( "Reset" ) ) {
-            renderer->bus.DebugReset();
-            if ( auto *logWindow = renderer->ui.GetComponent<LogWindow>() ) {
-                logWindow->Clear();
-            }
         }
     }
 };

--- a/frontend/ui/pattern-tables.h
+++ b/frontend/ui/pattern-tables.h
@@ -4,6 +4,7 @@
 #include "ui-component.h"
 #include "custom-components.h"
 #include "renderer.h"
+#include "log.h"
 #include <cstdio>
 #include <cstdint>
 #include <cmath>
@@ -43,6 +44,7 @@ class PatternTablesWindow : public UIComponent
 
         if ( ImGui::Begin( "Tiles", &visible, windowFlags ) ) {
             RenderMenuBar();
+            DebugControls();
 
             ImGui::PushFont( renderer->fontMono );
             LeftPanel();
@@ -238,11 +240,6 @@ class PatternTablesWindow : public UIComponent
         int const tileIndex = targetId / 16;
         ImGui::Text( "$%02X (%d)", tileIndex, tileIndex );
 
-        // Spacing();
-        // ImGui::Unindent( indentSpacing );
-        // ImGui::Text( "Palette In PPU Memory" );
-        // Palettes();
-
         ImGui::EndGroup();
     }
 
@@ -327,6 +324,34 @@ class PatternTablesWindow : public UIComponent
                 ImGui::EndMenu();
             }
             ImGui::EndMenuBar();
+        }
+    }
+
+    void DebugControls()
+    {
+        bool const isPaused = renderer->paused;
+
+        ImGui::BeginDisabled( !isPaused );
+        if ( ImGui::Button( "Continue" ) ) {
+            renderer->paused = false;
+        }
+        ImGui::EndDisabled();
+
+        ImGui::SameLine();
+
+        ImGui::BeginDisabled( isPaused );
+        if ( ImGui::Button( "Pause" ) ) {
+            renderer->paused = true;
+        }
+        ImGui::EndDisabled();
+
+        ImGui::SameLine();
+
+        if ( ImGui::Button( "Reset" ) ) {
+            renderer->bus.DebugReset();
+            if ( auto *logWindow = renderer->ui.GetComponent<LogWindow>() ) {
+                logWindow->Clear();
+            }
         }
     }
 };

--- a/frontend/ui/ppu-viewer.h
+++ b/frontend/ui/ppu-viewer.h
@@ -1,0 +1,432 @@
+#pragma once
+#include "bus.h"
+#include "ui-component.h"
+#include "renderer.h"
+#include <imgui.h>
+#include "log.h"
+#include <cinttypes>
+
+class PpuViewerWindow : public UIComponent
+{
+  public:
+    PpuViewerWindow( Renderer *renderer ) : UIComponent( renderer ) { visible = false; }
+
+    /*
+    ################################
+    #           Variables          #
+    ################################
+    */
+
+    /*
+    ################################
+    #            Methods           #
+    ################################
+    */
+    void OnVisible() override {}
+    void OnHidden() override {}
+
+    void RenderSelf() override
+    {
+        ImVec2 const               outerWindowSize = ImVec2( 650, 800 );
+        constexpr ImGuiWindowFlags windowFlags = ImGuiWindowFlags_MenuBar;
+        ImGui::PushStyleVar( ImGuiStyleVar_WindowPadding, ImVec2( 10.0f, 10.0f ) );
+        ImGui::SetNextWindowSizeConstraints( outerWindowSize,
+                                             ImVec2( outerWindowSize.x + 100, outerWindowSize.y + 100 ) );
+
+        if ( ImGui::Begin( "PPU Viewer", &visible, windowFlags ) ) {
+            RenderMenuBar();
+            DebugControls();
+            ImGui::Spacing();
+            ImGui::PushFont( renderer->fontMono );
+
+            PpuCycles( ImVec2( 300, 140 ) );
+            ImGui::SameLine();
+            PpuStatus( ImVec2( 300, 140 ) );
+            ImGui::Spacing();
+            PpuCtrl( ImVec2( 300, 230 ) );
+            ImGui::SameLine();
+            PpuMask( ImVec2( 300, 230 ) );
+            ImGui::Spacing();
+            PpuOamAddr( ImVec2( 300, 140 ) );
+            ImGui::SameLine();
+            PpuVramAndScrolling( ImVec2( 300, 140 ) );
+            ImGui::Spacing();
+            PpuShifters( ImVec2( 300, 140 ) );
+
+            ImGui::PopFont();
+        }
+        ImGui::End();
+        ImGui::PopStyleVar();
+    }
+
+    void DebugControls()
+    {
+        bool const isPaused = renderer->paused;
+
+        ImGui::BeginDisabled( !isPaused );
+        if ( ImGui::Button( "Continue" ) ) {
+            renderer->paused = false;
+        }
+        ImGui::EndDisabled();
+
+        ImGui::SameLine();
+
+        ImGui::BeginDisabled( isPaused );
+        if ( ImGui::Button( "Pause" ) ) {
+            renderer->paused = true;
+        }
+        ImGui::EndDisabled();
+
+        ImGui::SameLine();
+
+        if ( ImGui::Button( "Reset" ) ) {
+            renderer->bus.DebugReset();
+            if ( auto *logWindow = renderer->ui.GetComponent<LogWindow>() ) {
+                logWindow->Clear();
+            }
+        }
+    }
+
+    void PpuCycles( ImVec2 size )
+    {
+        SectionTableStart( "Cycles", size, 2 );
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex( 0 );
+        ImGui::Text( "PPU Cycle" );
+        ImGui::TableSetColumnIndex( 1 );
+        auto cycles = renderer->bus.ppu.GetCycles();
+        ImGui::Text( "%" PRIu16, cycles );
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex( 0 );
+        ImGui::Text( "Scanline" );
+        ImGui::TableSetColumnIndex( 1 );
+        auto scanline = renderer->bus.ppu.GetScanline();
+        ImGui::Text( "%" PRId16, scanline );
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex( 0 );
+        ImGui::Text( "Frame" );
+        ImGui::TableSetColumnIndex( 1 );
+        auto frame = renderer->bus.ppu.GetFrame();
+        ImGui::Text( "%" PRIu64, frame );
+
+        SectionTableEnd();
+    }
+
+    void PpuCtrl( ImVec2 size )
+    {
+        SectionTableStart( "PPUCTRL", size, 3 );
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex( 0 );
+        ImGui::Text( "$2000" );
+        ImGui::TableSetColumnIndex( 1 );
+        ImGui::Text( "PPUCTRL" );
+        ImGui::TableSetColumnIndex( 2 );
+        auto ppuCtrl = renderer->bus.ppu.GetPpuCtrl();
+        ImGui::Text( "$%02X", ppuCtrl );
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex( 0 );
+        ImGui::Text( "$2000.0" );
+        ImGui::TableSetColumnIndex( 1 );
+        ImGui::Text( "Nametable X" );
+        ImGui::TableSetColumnIndex( 2 );
+        ImGui::Text( "%d", renderer->bus.ppu.GetCtrlNametableX() );
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex( 0 );
+        ImGui::Text( "$2000.1" );
+        ImGui::TableSetColumnIndex( 1 );
+        ImGui::Text( "Nametable Y" );
+        ImGui::TableSetColumnIndex( 2 );
+        ImGui::Text( "%d", renderer->bus.ppu.GetCtrlNametableY() );
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex( 0 );
+        ImGui::Text( "$2000.2" );
+        ImGui::TableSetColumnIndex( 1 );
+        ImGui::Text( "Inc Mode" );
+        ImGui::TableSetColumnIndex( 2 );
+        auto incMode = renderer->bus.ppu.GetCtrlIncrementMode();
+        switch ( incMode ) {
+            case 0:
+                ImGui::Text( "$%02X (1)", 0 );
+                break;
+            case 1:
+                ImGui::Text( "$%02X (32)", 1 );
+                break;
+            default:
+                break;
+        }
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex( 0 );
+        ImGui::Text( "$2000.3" );
+        ImGui::TableSetColumnIndex( 1 );
+        ImGui::Text( "Pattern Sprite" );
+        ImGui::TableSetColumnIndex( 2 );
+        ImGui::Text( "%d", renderer->bus.ppu.GetCtrlPatternSprite() );
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex( 0 );
+        ImGui::Text( "$2000.4" );
+        ImGui::TableSetColumnIndex( 1 );
+        ImGui::Text( "Pattern Bg" );
+        ImGui::TableSetColumnIndex( 2 );
+        ImGui::Text( "%d", renderer->bus.ppu.GetCtrlPatternBackground() );
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex( 0 );
+        ImGui::Text( "$2000.5" );
+        ImGui::TableSetColumnIndex( 1 );
+        ImGui::Text( "Sprite Size" );
+        ImGui::TableSetColumnIndex( 2 );
+        ImGui::Text( "%d", renderer->bus.ppu.GetCtrlSpriteSize() );
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex( 0 );
+        ImGui::Text( "$2000.7" );
+        ImGui::TableSetColumnIndex( 1 );
+        ImGui::Text( "NMI Enable" );
+        ImGui::TableSetColumnIndex( 2 );
+        ImGui::Text( "%d", renderer->bus.ppu.GetCtrlNmiEnable() );
+
+        SectionTableEnd();
+    }
+
+    void PpuMask( ImVec2 size )
+    {
+        SectionTableStart( "PPUMASK", size, 3 );
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex( 0 );
+        ImGui::Text( "$2001" );
+        ImGui::TableSetColumnIndex( 1 );
+        ImGui::Text( "PPUMASK" );
+        ImGui::TableSetColumnIndex( 2 );
+        auto ppuMask = renderer->bus.ppu.GetPpuMask();
+        ImGui::Text( "$%02X", ppuMask );
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex( 0 );
+        ImGui::Text( "$2001.0" );
+        ImGui::TableSetColumnIndex( 1 );
+        ImGui::Text( "Grayscale" );
+        ImGui::TableSetColumnIndex( 2 );
+        ImGui::Text( "%d", renderer->bus.ppu.GetMaskGrayscale() );
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex( 0 );
+        ImGui::Text( "$2001.1" );
+        ImGui::TableSetColumnIndex( 1 );
+        ImGui::Text( "Show Bg Left" );
+        ImGui::TableSetColumnIndex( 2 );
+        ImGui::Text( "%d", renderer->bus.ppu.GetMaskShowBgLeft() );
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex( 0 );
+        ImGui::Text( "$2001.2" );
+        ImGui::TableSetColumnIndex( 1 );
+        ImGui::Text( "Show Spr Left" );
+        ImGui::TableSetColumnIndex( 2 );
+        ImGui::Text( "%d", renderer->bus.ppu.GetMaskShowSpritesLeft() );
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex( 0 );
+        ImGui::Text( "$2001.3" );
+        ImGui::TableSetColumnIndex( 1 );
+        ImGui::Text( "Show Bg" );
+        ImGui::TableSetColumnIndex( 2 );
+        ImGui::Text( "%d", renderer->bus.ppu.GetMaskShowBg() );
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex( 0 );
+        ImGui::Text( "$2001.4" );
+        ImGui::TableSetColumnIndex( 1 );
+        ImGui::Text( "Show Spr" );
+        ImGui::TableSetColumnIndex( 2 );
+        ImGui::Text( "%d", renderer->bus.ppu.GetMaskShowSprites() );
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex( 0 );
+        ImGui::Text( "$2001.5" );
+        ImGui::TableSetColumnIndex( 1 );
+        ImGui::Text( "Red Tint" );
+        ImGui::TableSetColumnIndex( 2 );
+        ImGui::Text( "%d", renderer->bus.ppu.GetMaskEnhanceRed() );
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex( 0 );
+        ImGui::Text( "$2001.6" );
+        ImGui::TableSetColumnIndex( 1 );
+        ImGui::Text( "Green Tint" );
+        ImGui::TableSetColumnIndex( 2 );
+        ImGui::Text( "%d", renderer->bus.ppu.GetMaskEnhanceGreen() );
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex( 0 );
+        ImGui::Text( "$2001.7" );
+        ImGui::TableSetColumnIndex( 1 );
+        ImGui::Text( "Blue Tint" );
+        ImGui::TableSetColumnIndex( 2 );
+        ImGui::Text( "%d", renderer->bus.ppu.GetMaskEnhanceBlue() );
+
+        SectionTableEnd();
+    }
+
+    void PpuOamAddr( ImVec2 size )
+    {
+        SectionTableStart( "OAMADDR", size, 3 );
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex( 0 );
+        ImGui::Text( "$2003" );
+        ImGui::TableSetColumnIndex( 1 );
+        ImGui::Text( "OAMADDR" );
+        ImGui::TableSetColumnIndex( 2 );
+        auto oamAddr = renderer->bus.ppu.GetOamAddr();
+        ImGui::Text( "$%02X", oamAddr );
+
+        SectionTableEnd();
+    }
+
+    void PpuStatus( ImVec2 size )
+    {
+        SectionTableStart( "PPUSTATUS", size, 3 );
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex( 0 );
+        ImGui::Text( "$2002" );
+        ImGui::TableSetColumnIndex( 1 );
+        ImGui::Text( "PPUSTATUS" );
+        ImGui::TableSetColumnIndex( 2 );
+        auto ppuStatus = renderer->bus.ppu.GetPpuStatus();
+        ImGui::Text( "$%02X", ppuStatus );
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex( 0 );
+        ImGui::Text( "$2002.5" );
+        ImGui::TableSetColumnIndex( 1 );
+        ImGui::Text( "Sprite Overflow" );
+        ImGui::TableSetColumnIndex( 2 );
+        ImGui::Text( "%d", renderer->bus.ppu.GetStatusSpriteOverflow() );
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex( 0 );
+        ImGui::Text( "$2002.6" );
+        ImGui::TableSetColumnIndex( 1 );
+        ImGui::Text( "Sprite 0 Hit" );
+        ImGui::TableSetColumnIndex( 2 );
+        ImGui::Text( "%d", renderer->bus.ppu.GetStatusSpriteZeroHit() );
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex( 0 );
+        ImGui::Text( "$2002.7" );
+        ImGui::TableSetColumnIndex( 1 );
+        ImGui::Text( "Vblank" );
+        ImGui::TableSetColumnIndex( 2 );
+        ImGui::Text( "%d", renderer->bus.ppu.GetStatusVblank() );
+
+        SectionTableEnd();
+    }
+
+    void PpuVramAndScrolling( ImVec2 size )
+    {
+        SectionTableStart( "VRAM and Scrolling", size, 2 );
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex( 0 );
+        ImGui::Text( "VRAM Addr" );
+        ImGui::TableSetColumnIndex( 1 );
+        auto vramAddr = renderer->bus.ppu.GetVramAddr();
+        ImGui::Text( "$%04X", vramAddr );
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex( 0 );
+        ImGui::Text( "Temp Addr" );
+        ImGui::TableSetColumnIndex( 1 );
+        auto tempAddr = renderer->bus.ppu.GetTempAddr();
+        ImGui::Text( "$%04X", tempAddr );
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex( 0 );
+        ImGui::Text( "Fine X" );
+        ImGui::TableSetColumnIndex( 1 );
+        auto fineX = renderer->bus.ppu.GetFineX();
+        ImGui::Text( "$%02X", fineX );
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex( 0 );
+        ImGui::Text( "Addr Latch" );
+        ImGui::TableSetColumnIndex( 1 );
+        auto addrLatch = renderer->bus.ppu.GetAddrLatch();
+        ImGui::Text( "$%02X", addrLatch );
+
+        SectionTableEnd();
+    }
+
+    void PpuShifters( ImVec2 size )
+    {
+
+        SectionTableStart( "Shifters", size, 2 );
+
+        ImGui::TableNextRow();
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex( 0 );
+        ImGui::Text( "Bg Pattern Low" );
+        ImGui::TableSetColumnIndex( 1 );
+        auto bgPatternLow = renderer->bus.ppu.GetBgShiftPatternLow();
+        ImGui::Text( "$%04X", bgPatternLow );
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex( 0 );
+        ImGui::Text( "Bg Pattern High" );
+        ImGui::TableSetColumnIndex( 1 );
+        auto bgPatternHigh = renderer->bus.ppu.GetBgShiftPatternHigh();
+        ImGui::Text( "$%04X", bgPatternHigh );
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex( 0 );
+        ImGui::Text( "Bg Attr Low" );
+        ImGui::TableSetColumnIndex( 1 );
+        auto bgAttrLow = renderer->bus.ppu.GetBgShiftAttributeLow();
+        ImGui::Text( "$%04X", bgAttrLow );
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex( 0 );
+        ImGui::Text( "Bg Attr High" );
+        ImGui::TableSetColumnIndex( 1 );
+        auto bgAttrHigh = renderer->bus.ppu.GetBgShiftAttributeHigh();
+        ImGui::Text( "$%04X", bgAttrHigh );
+
+        SectionTableEnd();
+    }
+
+    static void SectionTableStart( const char *label, ImVec2 size, int columns )
+    {
+        static ImGuiTableFlags flags = ImGuiTableFlags_SizingFixedFit | ImGuiTableFlags_SizingStretchSame |
+                                       ImGuiTableFlags_Resizable | ImGuiTableFlags_Borders;
+        ImGui::PushStyleColor( ImGuiCol_ChildBg, ImVec4( 1.0f, 1.0f, 1.0f, 1.0f ) );
+        ImGui::BeginChild( label, size, ImGuiChildFlags_Border );
+        ImGui::PopStyleColor();
+        ImGui::SeparatorText( label );
+        ImGui::BeginTable( label, columns, flags );
+    }
+
+    static void SectionTableEnd()
+    {
+        ImGui::EndTable();
+        ImGui::EndChild();
+    }
+
+    void RenderMenuBar()
+    {
+        if ( ImGui::BeginMenuBar() ) {
+            if ( ImGui::BeginMenu( "File" ) ) {
+                if ( ImGui::MenuItem( "Close" ) ) {
+                    visible = false;
+                }
+                ImGui::EndMenu();
+            }
+            ImGui::EndMenuBar();
+        }
+    }
+};

--- a/frontend/ui/ppu-viewer.h
+++ b/frontend/ui/ppu-viewer.h
@@ -3,7 +3,6 @@
 #include "ui-component.h"
 #include "renderer.h"
 #include <imgui.h>
-#include "log.h"
 #include <cinttypes>
 
 class PpuViewerWindow : public UIComponent
@@ -27,7 +26,7 @@ class PpuViewerWindow : public UIComponent
 
     void RenderSelf() override
     {
-        ImVec2 const               outerWindowSize = ImVec2( 650, 800 );
+        ImVec2 const               outerWindowSize = ImVec2( 650, 880 );
         constexpr ImGuiWindowFlags windowFlags = ImGuiWindowFlags_MenuBar;
         ImGui::PushStyleVar( ImGuiStyleVar_WindowPadding, ImVec2( 10.0f, 10.0f ) );
         ImGui::SetNextWindowSizeConstraints( outerWindowSize,
@@ -57,34 +56,6 @@ class PpuViewerWindow : public UIComponent
         }
         ImGui::End();
         ImGui::PopStyleVar();
-    }
-
-    void DebugControls()
-    {
-        bool const isPaused = renderer->paused;
-
-        ImGui::BeginDisabled( !isPaused );
-        if ( ImGui::Button( "Continue" ) ) {
-            renderer->paused = false;
-        }
-        ImGui::EndDisabled();
-
-        ImGui::SameLine();
-
-        ImGui::BeginDisabled( isPaused );
-        if ( ImGui::Button( "Pause" ) ) {
-            renderer->paused = true;
-        }
-        ImGui::EndDisabled();
-
-        ImGui::SameLine();
-
-        if ( ImGui::Button( "Reset" ) ) {
-            renderer->bus.DebugReset();
-            if ( auto *logWindow = renderer->ui.GetComponent<LogWindow>() ) {
-                logWindow->Clear();
-            }
-        }
     }
 
     void PpuCycles( ImVec2 size )

--- a/frontend/ui/register-viewer.h
+++ b/frontend/ui/register-viewer.h
@@ -4,7 +4,7 @@
 #include "renderer.h"
 #include <imgui.h>
 #include "log.h"
-#include <inttypes.h>
+#include <cinttypes>
 
 class RegisterViewerWindow : public UIComponent
 {
@@ -12,7 +12,7 @@ class RegisterViewerWindow : public UIComponent
     CPU &cpu; // NOLINT
     RegisterViewerWindow( Renderer *renderer ) : UIComponent( renderer ), cpu( renderer->bus.cpu )
     {
-        visible = true;
+        visible = false;
     }
 
     /*

--- a/include/cpu.h
+++ b/include/cpu.h
@@ -83,12 +83,20 @@ class CPU
     std::string             LogLineAtPC( bool verbose = true );
     std::deque<std::string> GetTracelog() const { return _traceLog; }
     std::deque<std::string> GetMesenFormatTracelog() const { return _mesenFormatTraceLog; }
-    void                    EnableTracelog() { _traceEnabled = true; }
-    void                    DisableTracelog() { _traceEnabled = false; }
-    void                    EnableJsonTestMode() { _isTestMode = true; }
-    void                    DisableJsonTestMode() { _isTestMode = false; }
-    void                    EnableMesenFormatTraceLog() { _mesenFormatTraceEnabled = true; }
-    void                    DisableMesenFormatTraceLog() { _mesenFormatTraceEnabled = false; }
+    void                    EnableTracelog()
+    {
+        _traceEnabled = true;
+        _mesenFormatTraceEnabled = false;
+    }
+    void EnableMesenFormatTraceLog()
+    {
+        _mesenFormatTraceEnabled = true;
+        _traceEnabled = false;
+    }
+    void DisableTracelog() { _traceEnabled = false; }
+    void DisableMesenFormatTraceLog() { _mesenFormatTraceEnabled = false; }
+    void EnableJsonTestMode() { _isTestMode = true; }
+    void DisableJsonTestMode() { _isTestMode = false; }
 
     u16  traceSize = 100;
     u16  mesenTraceSize = 100;

--- a/include/cpu.h
+++ b/include/cpu.h
@@ -35,6 +35,15 @@ class CPU
     bool IsReading2002() const { return _reading2002; }
     bool IsNmiInProgress() const { return _nmiInProgress; }
 
+    // status getters
+    u8 GetCarryFlag() const { return _p & Carry; }
+    u8 GetZeroFlag() const { return _p & Zero; }
+    u8 GetInterruptDisableFlag() const { return _p & InterruptDisable; }
+    u8 GetDecimalFlag() const { return _p & Decimal; }
+    u8 GetBreakFlag() const { return _p & Break; }
+    u8 GetOverflowFlag() const { return _p & Overflow; }
+    u8 GetNegativeFlag() const { return _p & Negative; }
+
     /*
     ################################
     ||           Setters          ||

--- a/include/cpu.h
+++ b/include/cpu.h
@@ -82,12 +82,16 @@ class CPU
     */
     std::string             LogLineAtPC( bool verbose = true );
     std::deque<std::string> GetTracelog() const { return _traceLog; }
+    std::deque<std::string> GetMesenFormatTracelog() const { return _mesenFormatTraceLog; }
     void                    EnableTracelog() { _traceEnabled = true; }
     void                    DisableTracelog() { _traceEnabled = false; }
     void                    EnableJsonTestMode() { _isTestMode = true; }
     void                    DisableJsonTestMode() { _isTestMode = false; }
+    void                    EnableMesenFormatTraceLog() { _mesenFormatTraceEnabled = true; }
+    void                    DisableMesenFormatTraceLog() { _mesenFormatTraceEnabled = false; }
 
-    u16  traceSize = 1000;
+    u16  traceSize = 100;
+    u16  mesenTraceSize = 100;
     void AddTraceLog( const std::string &log )
     {
         if ( _traceEnabled ) {
@@ -97,7 +101,17 @@ class CPU
             }
         }
     }
-    void ClearTracelog() { _traceLog.clear(); }
+    void ClearTraceLog() { _traceLog.clear(); }
+    void AddMesenTracelog( const std::string &log )
+    {
+        if ( _mesenFormatTraceEnabled ) {
+            _mesenFormatTraceLog.push_back( log + "\n" );
+            if ( _mesenFormatTraceLog.size() > mesenTraceSize ) {
+                _mesenFormatTraceLog.pop_front();
+            }
+        }
+    }
+    void ClearMesenTraceLog() { _mesenFormatTraceLog.clear(); }
 
     /*
     ################################
@@ -151,9 +165,11 @@ class CPU
     */
     bool _isTestMode = false;
     bool _traceEnabled = false;
-    bool _isPaused = false;
+    bool _mesenFormatTraceEnabled = false;
+    bool _didMesenTrace = false;
 
     std::deque<std::string> _traceLog;
+    std::deque<std::string> _mesenFormatTraceLog;
 
     /*
     ################################

--- a/include/ppu.h
+++ b/include/ppu.h
@@ -293,7 +293,7 @@ class PPU
             // Grab the attribute byte, which covers a 32x32 area
             u8 const  attrX = tileX / 4;
             u8 const  attrY = tileY / 4;
-            u16 const attrAddr = attrBase + (attrY * 8) + attrX;
+            u16 const attrAddr = attrBase + ( attrY * 8 ) + attrX;
             u8 const  attributeByte = Read( attrAddr );
 
             // Determine which 4x4 quadrant the tile is in
@@ -326,7 +326,7 @@ class PPU
                     int const screenPixelX = ( tileX * 8 ) + tilePixelX;
                     int const screenPixelY = ( tileY * 8 ) + pixelRow;
                     int const bufferIdx = ( screenPixelY * 256 ) + screenPixelX;
-                    u8 const  finalColorIdx = (paletteIdx * 4) + colorIdx;
+                    u8 const  finalColorIdx = ( paletteIdx * 4 ) + colorIdx;
                     buffer.at( bufferIdx ) = GetPpuPaletteColor( finalColorIdx );
                 }
             }

--- a/include/ppu.h
+++ b/include/ppu.h
@@ -23,11 +23,51 @@ class PPU
     ||           Getters          ||
     ################################
     */
-    [[nodiscard]] MirrorMode GetMirrorMode() const;
-    [[nodiscard]] s16        GetScanline() const { return _scanline; }
-    [[nodiscard]] u16        GetCycles() const { return _cycle; }
-    [[nodiscard]] u64        GetFrame() const { return _frame; }
-    [[nodiscard]] u32 GetMasterPaletteColor( u8 index ) const { return _nesPaletteRgbValues.at( index ); }
+    MirrorMode GetMirrorMode() const;
+    s16        GetScanline() const { return _scanline; }
+    u16        GetCycles() const { return _cycle; }
+    u64        GetFrame() const { return _frame; }
+    u32        GetMasterPaletteColor( u8 index ) const { return _nesPaletteRgbValues.at( index ); }
+
+    u8 GetPpuCtrl() const { return _ppuCtrl.value; }
+    u8 GetCtrlNametableX() const { return _ppuCtrl.bit.nametableX; }
+    u8 GetCtrlNametableY() const { return _ppuCtrl.bit.nametableY; }
+    u8 GetCtrlIncrementMode() const { return _ppuCtrl.bit.vramIncrement; }
+    u8 GetCtrlPatternSprite() const { return _ppuCtrl.bit.patternSprite; }
+    u8 GetCtrlPatternBackground() const { return _ppuCtrl.bit.patternBackground; }
+    u8 GetCtrlSpriteSize() const { return _ppuCtrl.bit.spriteSize; }
+    u8 GetCtrlNmiEnable() const { return _ppuCtrl.bit.nmiEnable; }
+
+    u8 GetPpuMask() const { return _ppuMask.value; }
+    u8 GetMaskGrayscale() const { return _ppuMask.bit.grayscale; }
+    u8 GetMaskShowBgLeft() const { return _ppuMask.bit.renderBackgroundLeft; }
+    u8 GetMaskShowSpritesLeft() const { return _ppuMask.bit.renderSpritesLeft; }
+    u8 GetMaskShowBg() const { return _ppuMask.bit.renderBackground; }
+    u8 GetMaskShowSprites() const { return _ppuMask.bit.renderSprites; }
+    u8 GetMaskEnhanceRed() const { return _ppuMask.bit.enhanceRed; }
+    u8 GetMaskEnhanceGreen() const { return _ppuMask.bit.enhanceGreen; }
+    u8 GetMaskEnhanceBlue() const { return _ppuMask.bit.enhanceBlue; }
+
+    u8 GetPpuStatus() const { return _ppuStatus.value; }
+    u8 GetStatusSpriteOverflow() const { return _ppuStatus.bit.spriteOverflow; }
+    u8 GetStatusSpriteZeroHit() const { return _ppuStatus.bit.spriteZeroHit; }
+    u8 GetStatusVblank() const { return _ppuStatus.bit.verticalBlank; }
+
+    u8 GetOamAddr() const { return _oamAddr; }
+    u8 GetOamData() const { return _oamData; }
+    u8 GetPpuScroll() const { return _ppuScroll; }
+    u8 GetPpuAddr() const { return _ppuAddr; }
+    u8 GetPpuData() const { return _ppuData; }
+
+    u16 GetVramAddr() const { return _vramAddr.value; }
+    u16 GetTempAddr() const { return _tempAddr.value; }
+    u8  GetFineX() const { return _fineX; }
+    u8  GetAddrLatch() const { return _addrLatch; }
+
+    u16 GetBgShiftPatternLow() const { return _bgShiftPatternLow; }
+    u16 GetBgShiftPatternHigh() const { return _bgShiftPatternHigh; }
+    u16 GetBgShiftAttributeLow() const { return _bgShiftAttributeLow; }
+    u16 GetBgShiftAttributeHigh() const { return _bgShiftAttributeHigh; }
 
     /*
     ################################
@@ -232,8 +272,8 @@ class PPU
         +++----------------- fine Y scroll
         */
 
-        u16 vramEnd = vramStart + 960;
-        u16 attrBase = vramStart + 960;
+        u16 const vramEnd = vramStart + 960;
+        u16 const attrBase = vramStart + 960;
 
         for ( int vramAddr = vramStart; vramAddr < vramEnd; vramAddr++ ) {
 
@@ -253,7 +293,7 @@ class PPU
             // Grab the attribute byte, which covers a 32x32 area
             u8 const  attrX = tileX / 4;
             u8 const  attrY = tileY / 4;
-            u16 const attrAddr = attrBase + attrY * 8 + attrX;
+            u16 const attrAddr = attrBase + (attrY * 8) + attrX;
             u8 const  attributeByte = Read( attrAddr );
 
             // Determine which 4x4 quadrant the tile is in
@@ -286,7 +326,7 @@ class PPU
                     int const screenPixelX = ( tileX * 8 ) + tilePixelX;
                     int const screenPixelY = ( tileY * 8 ) + pixelRow;
                     int const bufferIdx = ( screenPixelY * 256 ) + screenPixelX;
-                    u8 const  finalColorIdx = paletteIdx * 4 + colorIdx;
+                    u8 const  finalColorIdx = (paletteIdx * 4) + colorIdx;
                     buffer.at( bufferIdx ) = GetPpuPaletteColor( finalColorIdx );
                 }
             }


### PR DESCRIPTION
Closes #176 
Closes #177 
Closes #143 
Closes #162

### Nametable Viewer
I isolated the rendering logic to focus strictly on reading and combining the appropriate places in memory into a pixel buffer. The output is definitely not correct. I'm using the PPU internal Reads to grab this data, so it may be telling of other issues. 
![Screenshot 2025-03-07 at 1 28 33 PM](https://github.com/user-attachments/assets/21a2eb07-0df1-40d6-bdf3-f319040fa126)

### PPU Viewer
I renamed the register viewer to the CPU viewer, and I split off the PPU viewer into its own window
![Screenshot 2025-03-07 at 1 03 49 PM](https://github.com/user-attachments/assets/dd3f3977-8bfb-4fcf-b925-2c61fed3b7b3)

### Loading ROMs from the UI
I added the ability to swap a few preselected ROM options from the menu bar.

---
### Edit: More enhancements
- I expanded the debug controls and made them an inherited component for each UI class. 
- I added the option to view trace logs in a similar format as Mesen

### Memory Viewer enhancements
- The current value of PC is now highlighted, though it's a bit tough to find.
- The header row is sticky
- Cells how get highlighted to make following the mouse easier.

![memory-demo](https://github.com/user-attachments/assets/c5771a76-5cff-4282-a652-8fd221a75e98)

