### PR TITLE
Optional tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,4 @@ vcpkg_installed/
 # Misc
 imgui.ini
 *.ini
+tools/python/__pycache__

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,17 @@ copy_asset(${TESTS_S}    ${TESTS_D})
 add_custom_target(copied_assets ALL DEPENDS emu_core)
 add_dependencies(copied_assets emu_core)
 
+#[[
+#######################################
+||                                   ||
+||  Interactive CLI Tool (optional)  ||
+||                                   ||
+#######################################
+]]
+if(PYTHON_BINDINGS)
+  add_subdirectory(tools/python)
+endif()
+
 
 #[[
 ################################################

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -20,6 +20,10 @@
           "type": "BOOL",
           "value": "ON"
         },
+        "PYTHON_BINDINGS": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
         "BUILD_TESTS": {
           "type": "BOOL",
           "value": "ON"
@@ -53,6 +57,25 @@
         "CMAKE_CXX_FLAGS": {
           "type": "STRING",
           "value": "-Werror"
+        }
+      }
+    },
+    {
+      "name": "python",
+      "description": "Core + python bindings, no frontend.",
+      "inherits": "default",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": {
+          "type": "STRING",
+          "value": "Debug"
+        },
+        "BUILD_FRONTEND": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "PYTHON_BINDINGS": {
+          "type": "BOOL",
+          "value": "ON"
         }
       }
     },
@@ -101,6 +124,11 @@
     {
       "name": "ci",
       "configurePreset": "ci",
+      "jobs": 2
+    },
+    {
+      "name": "python",
+      "configurePreset": "python",
       "jobs": 2
     },
     {

--- a/tools/asm/build.sh
+++ b/tools/asm/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Uses cl65 from the cc65 suite: https://cc65.github.io/
+# This will build a custom cartridge, based on custom.s
+
+# You can run the custom rom by placing it in the roms folder, and selecting
+# it from the file menu while the emulator is running.
+
+SRC=custom.s
+DST=../../roms/custom.nes
+FLAGS="--verbose --target nes --asm-define NTSC"
+
+cl65 $FLAGS -o $DST $SRC

--- a/tools/asm/custom.s
+++ b/tools/asm/custom.s
@@ -1,0 +1,154 @@
+.segment "HEADER"
+  ; .byte "NES", $1A      ; iNES header identifier
+  .byte $4E, $45, $53, $1A
+  .byte 2               ; 2x 16KB PRG code
+  .byte 1               ; 1x  8KB CHR data
+  .byte $01, $00        ; mapper 0, vertical mirroring
+
+.segment "VECTORS"
+  ;; When an NMI happens (once per frame if enabled) the label nmi:
+  .addr nmi
+  ;; When the processor first turns on or is reset, it will jump to the label reset:
+  .addr reset
+  ;; External interrupt IRQ (unused)
+  .addr 0
+
+; "nes" linker config requires a STARTUP section, even if it's empty
+.segment "STARTUP"
+
+; Main code segment for the program
+.segment "CODE"
+
+reset:
+  sei		; disable IRQs
+  cld		; disable decimal mode
+  ldx #$40
+  stx $4017	; disable APU frame IRQ
+  ldx #$ff 	; Set up stack
+  txs		;  .
+  inx		; now X = 0
+  stx $2000	; disable NMI
+  stx $2001 	; disable rendering
+  stx $4010 	; disable DMC IRQs
+
+;; first wait for vblank to make sure PPU is ready
+vblankwait1:
+  bit $2002
+  bpl vblankwait1
+
+clear_memory:
+  lda #$00
+  sta $0000, x
+  sta $0100, x
+  sta $0200, x
+  sta $0300, x
+  sta $0400, x
+  sta $0500, x
+  sta $0600, x
+  sta $0700, x
+  inx
+  bne clear_memory
+
+;; second wait for vblank, PPU is ready after this
+vblankwait2:
+  bit $2002
+  bpl vblankwait2
+
+main:
+load_palettes:
+  lda $2002
+  lda #$3f
+  sta $2006
+  lda #$00
+  sta $2006
+  ldx #$00
+@loop:
+  lda palettes, x
+  sta $2007
+  inx
+  cpx #$20
+  bne @loop
+
+enable_rendering:
+  lda #%10000000	; Enable NMI
+  sta $2000
+  lda #%00010000	; Enable Sprites
+  sta $2001
+
+forever:
+  jmp forever
+
+nmi:
+  ldx #$00 	; Set SPR-RAM address to 0
+  stx $2003
+@loop:	lda hello, x 	; Load the hello message into SPR-RAM
+  sta $2004
+  inx
+  cpx #$1c
+  bne @loop
+  rti
+
+hello:
+  .byte $00, $00, $00, $00 	; Why do I need these here?
+  .byte $00, $00, $00, $00
+  .byte $6c, $00, $00, $6c
+  .byte $6c, $01, $00, $76
+  .byte $6c, $02, $00, $80
+  .byte $6c, $02, $00, $8A
+  .byte $6c, $03, $00, $94
+
+palettes:
+  ; Background Palette
+  .byte $0f, $00, $00, $00
+  .byte $0f, $00, $00, $00
+  .byte $0f, $00, $00, $00
+  .byte $0f, $00, $00, $00
+
+  ; Sprite Palette
+  .byte $0f, $20, $00, $00
+  .byte $0f, $00, $00, $00
+  .byte $0f, $00, $00, $00
+  .byte $0f, $00, $00, $00
+
+; Character memory
+.segment "CHARS"
+  .byte %11000011	; H (00)
+  .byte %11000011
+  .byte %11000011
+  .byte %11111111
+  .byte %11111111
+  .byte %11000011
+  .byte %11000011
+  .byte %11000011
+  .byte $00, $00, $00, $00, $00, $00, $00, $00
+
+  .byte %11111111	; E (01)
+  .byte %11111111
+  .byte %11000000
+  .byte %11111100
+  .byte %11111100
+  .byte %11000000
+  .byte %11111111
+  .byte %11111111
+  .byte $00, $00, $00, $00, $00, $00, $00, $00
+
+  .byte %11000000	; L (02)
+  .byte %11000000
+  .byte %11000000
+  .byte %11000000
+  .byte %11000000
+  .byte %11000000
+  .byte %11111111
+  .byte %11111111
+  .byte $00, $00, $00, $00, $00, $00, $00, $00
+
+  .byte %01111110	; O (03)
+  .byte %11100111
+  .byte %11000011
+  .byte %11000011
+  .byte %11000011
+  .byte %11000011
+  .byte %11100111
+  .byte %01111110
+  .byte $00, $00, $00, $00, $00, $00, $00, $00
+

--- a/tools/asm/readme.md
+++ b/tools/asm/readme.md
@@ -1,0 +1,3 @@
+You can build custom NES cartridges here.
+
+This requires the cc65 suite (<https://cc65.github.io/>)

--- a/tools/python/CMakeLists.txt
+++ b/tools/python/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.28.3)
+project(EmulatorCLI)
+
+# Find dependencies
+find_package(fmt CONFIG REQUIRED)
+find_package(Python COMPONENTS Interpreter Development REQUIRED)
+find_package(pybind11 CONFIG REQUIRED)
+
+# Build the Python module
+pybind11_add_module(emu MODULE emu.cpp)
+target_link_libraries(emu PRIVATE emu_core)
+target_link_libraries(emu PRIVATE fmt::fmt)
+
+# Place the module in the same directory as this CMakeLists.txt
+set_target_properties(emu PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+

--- a/tools/python/emu.cpp
+++ b/tools/python/emu.cpp
@@ -1,0 +1,186 @@
+#include "bus.h"
+#include <fmt/base.h>
+#include <pybind11/pybind11.h>
+#include "paths.h"
+
+namespace py = pybind11;
+
+class Emulator
+{
+  public:
+    Bus        bus;
+    PPU       &ppu = bus.ppu;
+    CPU       &cpu = bus.cpu;
+    Cartridge &cart = bus.cartridge;
+
+    Emulator() = default;
+
+    /*
+    #######################################
+    ||            CPU Getters            ||
+    #######################################
+    */
+    u64 GetCycles() const { return bus.cpu.GetCycles(); }
+    u8  A() const { return cpu.GetAccumulator(); }
+    u8  X() const { return cpu.GetXRegister(); }
+    u8  Y() const { return cpu.GetYRegister(); }
+    u8  SP() const { return cpu.GetStackPointer(); }
+    u16 PC() const { return cpu.GetProgramCounter(); }
+    u8  P() const { return cpu.GetStatusRegister(); }
+
+    u8 CarryFlag() const { return cpu.GetCarryFlag(); }
+    u8 ZeroFlag() const { return cpu.GetZeroFlag(); }
+    u8 InterruptFlag() const { return cpu.GetInterruptDisableFlag(); }
+    u8 DecimalFlag() const { return cpu.GetDecimalFlag(); }
+    u8 BreakFlag() const { return cpu.GetBreakFlag(); }
+    u8 OverflowFlag() const { return cpu.GetOverflowFlag(); }
+    u8 NegativeFlag() const { return cpu.GetNegativeFlag(); }
+
+    /*
+    #######################################
+    ||            CPU Setters            ||
+    #######################################
+    */
+    void SetCycles( u64 value ) { cpu.SetCycles( value ); }
+    void SetA( u8 value ) { cpu.SetAccumulator( value ); }
+    void SetX( u8 value ) { cpu.SetXRegister( value ); }
+    void SetY( u8 value ) { cpu.SetYRegister( value ); }
+    void SetSP( u8 value ) { cpu.SetStackPointer( value ); }
+    void SetPC( u16 value ) { cpu.SetProgramCounter( value ); }
+    void SetP( u8 value ) { cpu.SetStatusRegister( value ); }
+
+    /*
+    #######################################
+    ||            PPU Getters            ||
+    #######################################
+    */
+    u8  GetNmi() const { return ppu.GetCtrlNmiEnable(); }
+    u8  GetVblank() const { return ppu.GetStatusVblank(); }
+    u16 GetScanline() const { return ppu.scanline; }
+    u16 GetPpuCycles() const { return ppu.cycle; }
+    u64 GetFrame() const { return ppu.frame; }
+
+    /*
+    ################################
+    ||         PPU Setters        ||
+    ################################
+    */
+    void SetScanline( s16 value ) { ppu.scanline = value; }
+    void SetPpuCycles( s16 value ) { ppu.SetCycles( value ); }
+
+    /*
+    #######################################
+    ||         Cartridge Getters         ||
+    #######################################
+    */
+    bool DidMapperLoad() const { return cart.DidMapperLoad(); }
+    bool DoesMapperExist() const { return cart.DoesMapperExist(); }
+
+    /*
+    ################################
+    ||     Cartrdidge Setters     ||
+    ################################
+    */
+
+    /*
+    #######################################
+    ||              Methods              ||
+    #######################################
+    */
+    void Load( const std::string &path ) { bus.cartridge.LoadRom( path ); }
+
+    void Preset()
+    {
+        // Loads a common rom used for debugging to get going quickly.
+        std::string romFile = std::string( paths::roms() ) + "/custom.nes";
+        bus.cartridge.LoadRom( romFile );
+        bus.cpu.Reset();
+    }
+
+    void DebugReset() { bus.DebugReset(); }
+
+    static void Test() { fmt::print( "Test\n" ); }
+    void        Log()
+    {
+        auto out = bus.cpu.LogLineAtPC();
+        fmt::print( "{}\n", out );
+    }
+
+    void Step( int n = 1 )
+    {
+        for ( int i = 0; i < n; i++ ) {
+            bus.Clock();
+        }
+    }
+
+    u8 Read( u16 addr ) const { return bus.cpu.Read( addr ); }
+    u8 PpuRead( u16 addr ) { return bus.ppu.ReadVram( addr ); }
+
+    void EnableMesenTrace( int n = 100 )
+    {
+        cpu.EnableMesenFormatTraceLog();
+        cpu.SetMesenTraceSize( n );
+    }
+    void DisableMesenTrace() { cpu.DisableMesenFormatTraceLog(); }
+    void PrintMesenTrace() const
+    {
+        for ( const auto &line : cpu.GetMesenFormatTracelog() ) {
+            fmt::print( "{}", line );
+        }
+    }
+};
+
+PYBIND11_MODULE( emu, m ) // <-- Python module name. Must match the name in the CMakeLists
+{
+    py::class_<Emulator>( m, "Emulator" )
+        .def( py::init<>() )
+        // CPU Getters
+        .def_property_readonly( "cpu_cycles", &Emulator::GetCycles, "Get the number of cycles" )
+        .def_property_readonly( "a", &Emulator::A, "Get the accumulator" )
+        .def_property_readonly( "x", &Emulator::X, "Get the X register" )
+        .def_property_readonly( "y", &Emulator::Y, "Get the Y register" )
+        .def_property_readonly( "sp", &Emulator::SP, "Get the stack pointer" )
+        .def_property_readonly( "pc", &Emulator::PC, "Get the program counter" )
+        .def_property_readonly( "p", &Emulator::P, "Get the status register" )
+        .def_property_readonly( "carry_flag", &Emulator::CarryFlag, "Get the carry flag" )
+        .def_property_readonly( "zero_flag", &Emulator::ZeroFlag, "Get the zero flag" )
+        .def_property_readonly( "interrupt_flag", &Emulator::InterruptFlag, "Get the interrupt flag" )
+        .def_property_readonly( "decimal_flag", &Emulator::DecimalFlag, "Get the decimal flag" )
+        .def_property_readonly( "break_flag", &Emulator::BreakFlag, "Get the break flag" )
+        .def_property_readonly( "overflow_flag", &Emulator::OverflowFlag, "Get the overflow flag" )
+        .def_property_readonly( "negative_flag", &Emulator::NegativeFlag, "Get the negative flag" )
+        // CPU Setters
+        .def( "set_cycles", &Emulator::SetCycles, "Set the number of cycles" )
+        .def( "set_a", &Emulator::SetA, "Set the accumulator" )
+        .def( "set_x", &Emulator::SetX, "Set the X register" )
+        .def( "set_y", &Emulator::SetY, "Set the Y register" )
+        .def( "set_sp", &Emulator::SetSP, "Set the stack pointer" )
+        .def( "set_pc", &Emulator::SetPC, "Set the program counter" )
+        .def( "set_p", &Emulator::SetP, "Set the status register" )
+        // PPU Getters
+        .def_property_readonly( "nmi", &Emulator::GetNmi, "Get the PPU NMI flag" )
+        .def_property_readonly( "vblank", &Emulator::GetVblank, "Get the PPU VBLANK flag" )
+        .def_property_readonly( "scanline", &Emulator::GetScanline, "Get the scanline" )
+        .def_property_readonly( "ppu_cycles", &Emulator::GetPpuCycles, "Get the PPU cycles" )
+        .def_property_readonly( "frame", &Emulator::GetFrame, "Get the frame" )
+        // PPU Setters
+        .def( "set_scanline", &Emulator::SetScanline, "Set the scanline" )
+        .def( "set_ppu_cycles", &Emulator::SetPpuCycles, "Set the PPU cycles" )
+        // Cartridge Getters
+        .def_property_readonly( "did_mapper_load", &Emulator::DidMapperLoad, "Get if the mapper loaded" )
+        .def_property_readonly( "does_mapper_exist", &Emulator::DoesMapperExist, "Get if the mapper exists" )
+        // Cartridge Setters
+        // Methods
+        .def( "load", &Emulator::Load, "Load a rom file" )
+        .def( "preset", &Emulator::Preset, "Load custom.nes rom for debugging" )
+        .def( "debug_reset", &Emulator::DebugReset, "Reset the CPU and PPU" )
+        .def( "log", &Emulator::Log, "Log CPU state" )
+        .def( "step", &Emulator::Step, "Step the CPU by one or more cycles", py::arg( "n" ) = 1 )
+        .def( "enable_mesen_trace", &Emulator::EnableMesenTrace, "Enable Mesen trace log",
+              py::arg( "n" ) = 100 )
+        .def( "disable_mesen_trace", &Emulator::DisableMesenTrace, "Disable Mesen trace log" )
+        .def( "print_mesen_trace", &Emulator::PrintMesenTrace, "Print Mesen trace log" )
+        .def( "read", &Emulator::Read, "Read from CPU memory", py::arg( "addr" ) )
+        .def( "ppu_read", &Emulator::PpuRead, "Read from PPU memory", py::arg( "addr" ) )
+        .def_static( "test", &Emulator::Test, "Test function" );
+}

--- a/tools/python/emu.py
+++ b/tools/python/emu.py
@@ -1,0 +1,115 @@
+import sys
+import emu
+
+# ANSI escape codes for colors
+BLACK = "\033[30m"
+RED = "\033[31m"
+GREEN = "\033[32m"
+YELLOW = "\033[33m"
+BLUE = "\033[34m"
+MAGENTA = "\033[35m"
+CYAN = "\033[36m"
+WHITE = "\033[37m"
+RESET = "\033[0m"
+
+e = emu.Emulator()
+
+
+def print_interactive(msg):
+    """Prints messages to stderr so they are not captured when piping stdout."""
+    print(msg, file=sys.stderr)
+
+
+# This bit of logic, and method_names is to expose functions by name alone when running
+# this file in interactive mode (python3 -i emu.py). i.e. set_a() instead of e.set_a()
+def bind_method(method_name):
+    def wrapper(*args, **kwargs):
+        attr = getattr(e, method_name)
+        if callable(attr):
+            return attr(*args, **kwargs)
+        else:
+            return attr
+
+    wrapper.__name__ = method_name
+    return wrapper
+
+
+# Names of methods exposed globally to this file
+method_names = [
+    # CPU Getters
+    "cpu_cycles",
+    "a",
+    "x",
+    "y",
+    "p",
+    "sp",
+    "pc",
+    "carry_flag",
+    "zero_flag",
+    "interrupt_flag",
+    "decimal_flag",
+    "break_flag",
+    "overflow_flag",
+    "negative_flag",
+    # CPU Setters
+    "set_a",
+    "set_x",
+    "set_y",
+    "set_p",
+    "set_sp",
+    "set_pc",
+    "set_cycles"
+    # PPU Getters
+    "nmi",
+    "vblank",
+    "scanline",
+    "ppu_cycles",
+    "frame"
+    # PPU Setters
+    "set_scanline",
+    "set_ppu_cycles",
+    # Cartridge Getters
+    "did_mapper_load",
+    "does_mapper_exist",
+    # Cartridge Setters
+    # Methods
+    "log",
+    "step",
+    "test",
+    "enable_mesen_trace",
+    "disable_mesen_trace",
+    "print_mesen_trace",
+    "debug_reset",
+    "read",
+    "ppu_read",
+]
+for name in method_names:
+    globals()[name] = bind_method(name)
+
+
+def step_until(callback_condition):
+    while not callback_condition():
+        e.step()
+
+
+def commands():
+    for name in method_names:
+        print(f"{YELLOW}{name}(){RESET}")
+    print(f"{YELLOW}step_until(callback_condition){RESET}")
+    print(f"{YELLOW}out(filename){RESET} # Redirect stdout to a file")
+
+
+def step_and_trace(n=100):
+    e.enable_mesen_trace(n)
+    e.step(n)
+    e.print_mesen_trace()
+    e.disable_mesen_trace()
+
+
+def main():
+    e.load("../../roms/palette.nes")
+    e.log()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/python/readme.md
+++ b/tools/python/readme.md
@@ -1,0 +1,28 @@
+## Python Bindings
+
+The purpose of this directory to compile the emulator C++ core to a Python module. It does not effect the main build.
+
+### Pre-requisites
+
+Package installation is not handled by the main build system. To compile, you'll need to install the `pybind11` package. I recommend installing it with `pip`, either globally or in a virtual environment.
+
+`pip install pybind11`
+
+See the [pybind11 docs](https://pybind11.readthedocs.io/en/stable/installing.html#) for more details.
+
+### Build instructions
+
+- Run `scripts/build.sh` from this directory
+
+### Adding new methods
+
+- Add a wrapper method to `emu.cpp` and expose it to the `PYBIND11_MODULE`
+- Rebuild the module
+- Add the method name to `method_names` list in `emu.py`
+- Add function definition to `emu.pyi`, for linting and IDE hints
+
+### Usage
+
+- Add `import emu` to the top of any Python script, and you can use any of the exposed methods.
+- Execute as you would any other Python script `python3 emu.py` (or in a Python shell: `python3 -i emu.py`)
+- See `emu.py` and `test.py` for examples.

--- a/tools/python/readme.md
+++ b/tools/python/readme.md
@@ -4,11 +4,11 @@ The purpose of this directory to compile the emulator C++ core to a Python modul
 
 ### Pre-requisites
 
-Package installation is not handled by the main build system. To compile, you'll need to install the `pybind11` package. I recommend installing it with `pip`, either globally or in a virtual environment.
+Package installation is not handled by the main build system. To compile, you'll need to install the `pybind11` package system-wide.
 
-`pip install pybind11`
+`brew install pybind11`
 
-See the [pybind11 docs](https://pybind11.readthedocs.io/en/stable/installing.html#) for more details.
+See the [pybind11](https://pybind11.readthedocs.io/en/stable/installing.html#) for more details.
 
 ### Build instructions
 

--- a/tools/python/scripts/build.sh
+++ b/tools/python/scripts/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd "$(dirname "$BASH_SOURCE[0]")/../../.." || exit 1
+scripts/build.sh python

--- a/tools/python/test.py
+++ b/tools/python/test.py
@@ -1,0 +1,20 @@
+import unittest
+import emu
+
+
+class TestExample(unittest.TestCase):
+    def test_bug_1(self):
+        e = emu.Emulator()
+        e.load("../../roms/palette.nes")
+        e.debug_reset()
+        pal0 = e.ppu_read(0x3F00)
+        steps = 0
+        while pal0 == e.ppu_read(0x3F00):
+            e.step()
+            steps += 1
+        print(f"Steps: {steps}")
+        e.log()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #188 
Closes #189 

I've added two optional debugging tools. These tools are optional and should not effect the main build in any way. 

- `tools/asm` directory to build to build roms from assembly via the `cl65` compiler, from the [cc65](https://cc65.github.io/) tool set.
- `tools/python` provides an option to build the emulator as a python module, which can be imported and used in Python scripts
![bindings-demo](https://github.com/user-attachments/assets/7e72c716-fe33-42af-bcad-8e710451fb0c)

---
I've left readme files with instructions on how to get these working. 

The included assembly file is a barebones placeholder I used from a YouTube tutorial, I forgot the source unfortunately.