### PR TITLE
Mappers 3

### DIFF
--- a/core/mappers/mapper3.cpp
+++ b/core/mappers/mapper3.cpp
@@ -1,21 +1,22 @@
 #include "mapper3.h"
+#include "cartridge-header.h"
+#include "mappers/mapper-base.h"
+#include "global-types.h"
 
-Mapper3::Mapper3(iNes2Instance iNesHeader)
-    : Mapper(iNesHeader)
+Mapper3::Mapper3( iNes2Instance iNesHeader ) : Mapper( iNesHeader ), _chrBank(0)
 {
-    _chrBank = 0;
+    
 }
 
-u32 Mapper3::TranslateCPUAddress(u16 address)
+u32 Mapper3::TranslateCPUAddress( u16 address )
 {
     // CNROM: PRG is fixed, typically 32KB at $8000-$FFFF
     // Map $8000-$FFFF to PRG-ROM directly
-    if (address >= 0x8000)
-    {
+    if ( address >= 0x8000 ) {
         // If only 16KB PRG, mirror it
-        int prgBankCount = GetPrgBankCount();
+        int const prgBankCount = GetPrgBankCount();
         u32 prgAddr = address - 0x8000;
-        if (prgBankCount == 1) // 16KB
+        if ( prgBankCount == 1 ) // 16KB
             prgAddr = prgAddr % 0x4000;
         return prgAddr;
     }
@@ -23,33 +24,30 @@ u32 Mapper3::TranslateCPUAddress(u16 address)
     return 0;
 }
 
-u32 Mapper3::TranslatePPUAddress(u16 address)
+u32 Mapper3::TranslatePPUAddress( u16 address )
 {
     // CNROM: CHR is banked in 8KB units
-    if (address < 0x2000)
-    {
-        u32 chrBankCount = GetChrBankCount();
-        u32 bank = _chrBank % chrBankCount;
-        return (bank * 0x2000) + address;
+    if ( address < 0x2000 ) {
+        u32 const chrBankCount = GetChrBankCount();
+        u32 const bank = _chrBank % chrBankCount;
+        return ( bank * 0x2000 ) + address;
     }
     // Not CHR address
     return address;
 }
 
-void Mapper3::HandleCPUWrite(u16 address, u8 data)
+void Mapper3::HandleCPUWrite( u16 address, u8 data )
 {
     // Any write to $8000-$FFFF sets CHR bank
-    if (address >= 0x8000 && address <= 0xFFFF)
-    {
+    if ( address >= 0x8000 && address <= 0xFFFF ) {
         // Use a mask based on available CHR banks (support up to 8 banks)
-        u8 mask = (GetChrBankCount() > 0) ? (GetChrBankCount() - 1) : 0x03;
+        u8 const mask = ( GetChrBankCount() > 0 ) ? ( GetChrBankCount() - 1 ) : 0x03;
         _chrBank = data & mask;
     }
 }
 
-
 MirrorMode Mapper3::GetMirrorMode()
 {
     // Use mirroring from header
-    return iNes.GetMirrorMode();
+    return static_cast<MirrorMode>( iNes.GetMirroring() );
 }

--- a/core/mappers/mapper3.cpp
+++ b/core/mappers/mapper3.cpp
@@ -1,0 +1,55 @@
+#include "mapper3.h"
+
+Mapper3::Mapper3(iNes2Instance iNesHeader)
+    : Mapper(iNesHeader)
+{
+    _chrBank = 0;
+}
+
+u32 Mapper3::TranslateCPUAddress(u16 address)
+{
+    // CNROM: PRG is fixed, typically 32KB at $8000-$FFFF
+    // Map $8000-$FFFF to PRG-ROM directly
+    if (address >= 0x8000)
+    {
+        // If only 16KB PRG, mirror it
+        int prgBankCount = GetPrgBankCount();
+        u32 prgAddr = address - 0x8000;
+        if (prgBankCount == 1) // 16KB
+            prgAddr = prgAddr % 0x4000;
+        return prgAddr;
+    }
+    // Should not happen for CNROM
+    return 0;
+}
+
+u32 Mapper3::TranslatePPUAddress(u16 address)
+{
+    // CNROM: CHR is banked in 8KB units
+    if (address < 0x2000)
+    {
+        u32 chrBankCount = GetChrBankCount();
+        u32 bank = _chrBank % chrBankCount;
+        return (bank * 0x2000) + address;
+    }
+    // Not CHR address
+    return address;
+}
+
+void Mapper3::HandleCPUWrite(u16 address, u8 data)
+{
+    // Any write to $8000-$FFFF sets CHR bank
+    if (address >= 0x8000 && address <= 0xFFFF)
+    {
+        // Use a mask based on available CHR banks (support up to 8 banks)
+        u8 mask = (GetChrBankCount() > 0) ? (GetChrBankCount() - 1) : 0x03;
+        _chrBank = data & mask;
+    }
+}
+
+
+MirrorMode Mapper3::GetMirrorMode()
+{
+    // Use mirroring from header
+    return iNes.GetMirrorMode();
+}

--- a/core/mappers/mapper3.cpp
+++ b/core/mappers/mapper3.cpp
@@ -3,7 +3,7 @@
 #include "mappers/mapper-base.h"
 #include "global-types.h"
 
-Mapper3::Mapper3( iNes2Instance iNesHeader ) : Mapper( iNesHeader ) 
+Mapper3::Mapper3( iNes2Instance iNesHeader ) : Mapper( iNesHeader )
 {
 }
 

--- a/core/mappers/mapper3.cpp
+++ b/core/mappers/mapper3.cpp
@@ -3,9 +3,8 @@
 #include "mappers/mapper-base.h"
 #include "global-types.h"
 
-Mapper3::Mapper3( iNes2Instance iNesHeader ) : Mapper( iNesHeader ), _chrBank(0)
+Mapper3::Mapper3( iNes2Instance iNesHeader ) : Mapper( iNesHeader ) 
 {
-    
 }
 
 u32 Mapper3::TranslateCPUAddress( u16 address )
@@ -15,7 +14,7 @@ u32 Mapper3::TranslateCPUAddress( u16 address )
     if ( address >= 0x8000 ) {
         // If only 16KB PRG, mirror it
         int const prgBankCount = GetPrgBankCount();
-        u32 prgAddr = address - 0x8000;
+        u32       prgAddr = address - 0x8000;
         if ( prgBankCount == 1 ) // 16KB
             prgAddr = prgAddr % 0x4000;
         return prgAddr;

--- a/core/mappers/mapper3.h
+++ b/core/mappers/mapper3.h
@@ -10,15 +10,16 @@
 class Mapper3 : public Mapper
 {
   public:
-    Mapper3(iNes2Instance iNesHeader);
-    u32 TranslateCPUAddress(u16 address) override;
-    u32 TranslatePPUAddress(u16 address) override;
-    void HandleCPUWrite(u16 address, u8 data) override;
+    Mapper3( iNes2Instance iNesHeader );
+    u32  TranslateCPUAddress( u16 address ) override;
+    u32  TranslatePPUAddress( u16 address ) override;
+    void HandleCPUWrite( u16 address, u8 data ) override;
 
-    [[nodiscard]] bool SupportsPrgRam() override { return false; }
-    [[nodiscard]] bool HasExpansionRom() override { return false; }
-    [[nodiscard]] bool HasExpansionRam() override { return false; }
+    [[nodiscard]] bool       SupportsPrgRam() override { return false; }
+    [[nodiscard]] bool       HasExpansionRom() override { return false; }
+    [[nodiscard]] bool       HasExpansionRam() override { return false; }
     [[nodiscard]] MirrorMode GetMirrorMode() override;
+
   private:
     u8 _chrBank = 0;
 };

--- a/core/mappers/mapper3.h
+++ b/core/mappers/mapper3.h
@@ -1,0 +1,24 @@
+#pragma once
+#include "cartridge-header.h"
+#include "global-types.h"
+#include "mapper-base.h"
+
+/**
+ * @brief Mapper 3 (CNROM) implementation
+ * Supports simple CHR-ROM bank switching via CPU writes to $8000-$FFFF
+ */
+class Mapper3 : public Mapper
+{
+  public:
+    Mapper3(iNes2Instance iNesHeader);
+    u32 TranslateCPUAddress(u16 address) override;
+    u32 TranslatePPUAddress(u16 address) override;
+    void HandleCPUWrite(u16 address, u8 data) override;
+
+    [[nodiscard]] bool SupportsPrgRam() override { return false; }
+    [[nodiscard]] bool HasExpansionRom() override { return false; }
+    [[nodiscard]] bool HasExpansionRam() override { return false; }
+    [[nodiscard]] MirrorMode GetMirrorMode() override;
+  private:
+    u8 _chrBank = 0;
+};


### PR DESCRIPTION
Added Mapper 3 alongside the already existing Mapper 0,1 and 2. Mapper 3 is more focused around the CNROM Board. 

Used this [site](https://nesdev-wiki.nes.science/wikipages/INES_Mapper_003.xhtml) for reference