### PR TITLE
Added frame count to ui overlay

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,9 @@ if(BUILD_FRONTEND)
 
   file(GLOB FRONTEND_SOURCES "frontend/*.cpp" "frontend/ui/*.cpp")
   add_executable(emu ${FRONTEND_SOURCES})
+  if(WIN32)
+    target_link_options(emu PRIVATE "-Wl,/STACK:8388608")
+  endif()
 
   target_compile_definitions(emu PRIVATE NOMINMAX)
 

--- a/frontend/ui/overlay.h
+++ b/frontend/ui/overlay.h
@@ -32,6 +32,7 @@ public:
       ImGui::PushFont( renderer->fontMono );
       ImGui::Text( "CPU Cycle: " U64_FORMAT_SPECIFIER, renderer->bus.cpu.GetCycles() );
       ImGui::Text( "FPS(%.1f FPS)", renderer->io->Framerate );
+      ImGui::Text( "Frame Count: " U64_FORMAT_SPECIFIER, renderer->bus.ppu.frame );
       ImGui::PopFont();
     }
     ImGui::End();


### PR DESCRIPTION
Note that changes made to CMakeLists.txt only increase the stack size for a Windows build to successfully run.